### PR TITLE
Removed mentions of psij-ci-load since it has been phased out by

### DIFF
--- a/README-testing.md
+++ b/README-testing.md
@@ -28,7 +28,8 @@ use the provided setup script:
     ./psij-ci-setup
 ```
 
-or manually set up the CI runner with Cron or your favorite scheduler.
+or manually set up the CI runner (`psij-ci-run`) with Cron or your
+favorite scheduler.
 
 Note: If you need to set up an environment module (such as  `module load
 python/cpython-x.y.z`) or something similar, such as loading a conda or

--- a/README-testing.md
+++ b/README-testing.md
@@ -30,14 +30,11 @@ use the provided setup script:
 
 or manually set up the CI runner with Cron or your favorite scheduler.
 
-Note: If you need to set up an environment module (such as 
-`module load python/cpython-x.y.z`) or something similar, such as
-loading a conda or virtual environment, please add the relevant commands to
-`psij-ci-load`, which is sourced before tests are run by `psij-ci-run`. If the
-setup script is run under a venv or Conda, it will attempt to detect this and 
-ask whether the relevant environment activation commands should be added to 
-`psij-ci-load`. However, not all circumstances can be reliably detected and 
-you may need to manually edit `psij-ci-load`.
+Note: If you need to set up an environment module (such as  `module load
+python/cpython-x.y.z`) or something similar, such as loading a conda or
+virtual environment, please run the relevant commands before invoking
+`psij-ci-setup`.
+
 
 Testing with the CI runner
 ==========================

--- a/psij-ci-load
+++ b/psij-ci-load
@@ -1,4 +1,0 @@
-# This file can be used to set up an environment before tests are run.
-# For example, one can issue relevant "module load" commands here. The
-# file will then be sourced by both psij-ci-setup and psij-ci-run.
-

--- a/psij-ci-run
+++ b/psij-ci-run
@@ -16,7 +16,10 @@ failifempty() {
     fi
 }
 
-source psij-ci-load
+if [ -f psij-ci-load ]; then
+    source psij-ci-load
+fi
+
 if [ -f psij-ci-env ]; then
     source psij-ci-env
 fi

--- a/psij-ci-run
+++ b/psij-ci-run
@@ -16,10 +16,6 @@ failifempty() {
     fi
 }
 
-if [ -f psij-ci-load ]; then
-    source psij-ci-load
-fi
-
 if [ -f psij-ci-env ]; then
     source psij-ci-env
 fi

--- a/psij-ci-setup
+++ b/psij-ci-setup
@@ -188,8 +188,7 @@ echo "This script will install requirements for the PSI/J CI tests and"
 echo "add a cron job to run the tests once a day at some random time. "
 echo "                                                                "
 echo "If you need to set up a special environment, such as loading an "
-echo "environment module please exit this script and add the relevant "
-echo "commands to psij-ci-load.                                       "
+echo "environment module please do so and then re-run this script.    "
 echo "================================================================"
 echo
 


### PR DESCRIPTION
psij-ci-env. Psij-ci-run still attempts to load it if it's there just in case.