### PR TITLE
Repo rename prep

### DIFF
--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -50,12 +50,13 @@ def read_conf(fname: str) -> Dict[str, str]:
     return conf
 
 
-def run(*args: str, cwd: Optional[str] = None) -> None:
+def run(*args: str, cwd: Optional[str] = None) -> str:
     p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False,
                        cwd=cwd, text=True)
     if p.returncode != 0:
         print(p.stdout)
         raise subprocess.CalledProcessError(p.returncode, args, output=p.stdout)
+    return p.stdout
 
 
 def get_conf(conf: Dict[str, str], name: str) -> str:

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -162,7 +162,7 @@ NEW_REPO = 'ExaWorks/psij-python'
 
 
 def patch_file(file_name: str) -> None:
-    if os._exists(file_name + '.is_patched'):
+    if os.path.exists(file_name + '.is_patched'):
         return
 
     with info('Pathcing %s' % file_name):

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -165,7 +165,7 @@ def patch_file(file_name: str) -> None:
     if os.path.exists(file_name + '.is_patched'):
         return
 
-    with info('Pathcing %s' % file_name):
+    with info('Patching %s' % file_name):
         with open(file_name) as inf:
             with open(file_name + '._new_', 'w') as outf:
                 for line in inf:

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -157,6 +157,44 @@ def run_tests(conf: Dict[str, str], site_ids: List[str], branches: List[str], cl
                     run_branch_tests(conf, tmpp, run_id, clone, site_id, branch)
 
 
+OLD_REPO = 'ExaWorks/psi-j-python'
+NEW_REPO = 'ExaWorks/psij-python'
+
+
+def patch_file(file_name: str) -> None:
+    if os._exists(file_name + '.is_patched'):
+        return
+
+    with info('Pathcing %s' % file_name):
+        with open(file_name) as inf:
+            with open(file_name + '._new_', 'w') as outf:
+                for line in inf:
+                    # strip new line
+                    if line.find(OLD_REPO) != -1:
+                        # we're adding one space so that the line has the same length;
+                        # when invoking a subprocess, bash stores the location where
+                        # it's supposed to continue parsing from, so it's a good idea
+                        # to to not move things around
+                        line = line.replace(OLD_REPO, NEW_REPO)[:-1] + ' \n'
+                    outf.write(line)
+        os.chmod(file_name + '._new_', os.stat(file_name).st_mode)
+        os.rename(file_name + '._new_', file_name)
+        Path(file_name + '.is_patched').touch()
+
+
+def patch_repo() -> None:
+    patch_file('testing.conf')
+    patch_file('psij-ci-run')
+
+
+def update_origin() -> None:
+    old_url = run('git', 'remote', 'get-url', 'origin')
+    new_url = old_url.strip().replace(OLD_REPO, NEW_REPO)
+    if new_url != old_url:
+        with info('Updating git url to %s' % new_url):
+            run('git', 'remote', 'set-url', 'origin', new_url)
+
+
 @contextmanager
 def info(msg: str) -> Generator[bool, None, None]:
     print(msg + '... ', end='')
@@ -193,4 +231,6 @@ if __name__ == '__main__':
     else:
         raise ValueError('Unrecognized value for scope: "%s"' % scope)
 
+    patch_repo()
+    update_origin()
     run_tests(conf, site_ids, branches, clone)


### PR DESCRIPTION
*PLEASE DON'T MERGE AFTER REVIEW*

This PR is in preparation for renaming the repo to "psij-python". It is needed because existing tests deployments will continue to reference the old repo. This PR modifies the test runner to patch relevant files and update to the new URL automatically.

The plan, once this is reviewed, is as follows:
- merge this
- immediately:
    - rename the repo
    - clone the repo to also have a copy in the old location so that running tests can get the updated test runner
    - (alternatively, we could clone the old repo, but it may be better to do a rename to ensure that all ancillary data -- e.g. wiki pages -- is preserved)
- add a warning to the clone (old URL) that the repo is not used any more and that existing checkouts should have their origin URLs updated
- archive the cloned repo (old URL) to prevent accidental writes/diverging development