### PR TITLE
`git fetch remote` fetches the remote into FETCH_HEAD not into origin…

### DIFF
--- a/psij-ci-run
+++ b/psij-ci-run
@@ -54,7 +54,7 @@ fi
 
 # Ensure latest test runner is there
 git fetch https://github.com/ExaWorks/psi-j-python.git
-git checkout origin/main -- tests/ci_runner.py
+git checkout FETCH_HEAD -- tests/ci_runner.py
 
 
 if [ "$REPEAT" == "1" ]; then


### PR DESCRIPTION
…/main.

So the line that follows doesn't really do anything. This fixes it to do the checkout from the nearly fetched data. Yay git!