### PR TITLE
Fix parsing of boolean config options, such as minimal_uploads.

### DIFF
--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -59,9 +59,12 @@ def run(*args: str, cwd: Optional[str] = None) -> str:
     return p.stdout
 
 
-def get_conf(conf: Dict[str, str], name: str) -> str:
+def get_conf(conf: Dict[str, str], name: str, default: Optional[str] = None) -> str:
     if name not in conf:
-        raise KeyError('Missing configuration option "%s"' % name)
+        if default is not None:
+            return default
+        else:
+            raise KeyError('Missing configuration option "%s"' % name)
     return conf[name]
 
 
@@ -118,7 +121,7 @@ def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool =
         args.append('--branch-name-override')
         args.append(fake_branch_name)
     for opt in ['maintainer_email', 'executors', 'server_url', 'key', 'max_age',
-                'custom_attributes', 'minimal_uploads']:
+                'custom_attributes']:
         try:
             val = get_conf(conf, opt)
             args.append('--' + opt.replace('_', '-'))
@@ -128,6 +131,11 @@ def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool =
             # old test cycles from working, if their configs don't contain
             # the new options
             pass
+
+    val = get_conf(conf, 'minimal_uploads', 'false')
+    if val == 'true':
+        args.append('--minimal-uploads')
+
     cwd = (dir / 'code') if clone else Path('.')
     env = dict(os.environ)
     env['PYTHONPATH'] = str(Path('.').resolve() / '.packages') \
@@ -175,7 +183,7 @@ def patch_file(file_name: str) -> None:
                         # when invoking a subprocess, bash stores the location where
                         # it's supposed to continue parsing from, so it's a good idea
                         # to to not move things around
-                        line = line.replace(OLD_REPO, NEW_REPO)[:-1] + ' \n'
+                        line = line.rstrip('\n').replace(OLD_REPO, NEW_REPO) + ' \n'
                     outf.write(line)
         os.chmod(file_name + '._new_', os.stat(file_name).st_mode)
         os.rename(file_name + '._new_', file_name)

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -183,7 +183,7 @@ def patch_file(file_name: str) -> None:
                         # when invoking a subprocess, bash stores the location where
                         # it's supposed to continue parsing from, so it's a good idea
                         # to to not move things around
-                        line = line.rstrip('\n').replace(OLD_REPO, NEW_REPO) + ' \n'
+                        line = line.replace(OLD_REPO, NEW_REPO)[:-1] + ' \n'
                     outf.write(line)
         os.chmod(file_name + '._new_', os.stat(file_name).st_mode)
         os.rename(file_name + '._new_', file_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -270,6 +270,10 @@ def _get_id(config):
         raise ValueError('Invalid value for --id argument: "%s"' % id)
 
 
+def _get_bool_option(config, name, default='false'):
+    return config.getoption(name, default=default).lower() == 'true'
+
+
 def _run(*args) -> str:
     process = subprocess.run(args, check=False, text=True,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -475,7 +479,7 @@ def _mk_test_fname(data):
 
 
 def _save_or_upload(config, data):
-    minimal = config.getoption('minimal_uploads')
+    minimal = _get_bool_option(config, 'minimal_uploads')
     save = config.getoption('save_results')
     upload = config.getoption('upload_results')
     if upload and minimal:
@@ -562,7 +566,8 @@ def _upload_report(config, data):
     env = config.option.environment
 
     url = config.getoption('server_url')
-    minimal = config.getoption('minimal_uploads')
+    minimal = _get_bool_option(config, 'minimal_uploads')
+    print('Minimal: %s' % minimal)
     if minimal:
         data = _sanitize(data)
     resp = requests.post('%s/result' % url, json={'id': env['config']['id'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ def pytest_addoption(parser):
                      help='Pretend that the current git branch is this value.')
     parser.addoption('--custom-attributes', action='store', default=None,
                      help='A set of custom attributes to pass to jobs.')
-    parser.addoption('--minimal-uploads', action='store', default=False,
+    parser.addoption('--minimal-uploads', action='store_true', default=False,
                      help='Enables minimal uploads mode, which restricts the information that '
                           'is uploaded to the test aggregation server. ')
 
@@ -268,10 +268,6 @@ def _get_id(config):
         return id[1:-1]
     else:
         raise ValueError('Invalid value for --id argument: "%s"' % id)
-
-
-def _get_bool_option(config, name, default='false'):
-    return config.getoption(name, default=default).lower() == 'true'
 
 
 def _run(*args) -> str:
@@ -479,7 +475,7 @@ def _mk_test_fname(data):
 
 
 def _save_or_upload(config, data):
-    minimal = _get_bool_option(config, 'minimal_uploads')
+    minimal = config.getoption('minimal_uploads')
     save = config.getoption('save_results')
     upload = config.getoption('upload_results')
     if upload and minimal:
@@ -566,7 +562,7 @@ def _upload_report(config, data):
     env = config.option.environment
 
     url = config.getoption('server_url')
-    minimal = _get_bool_option(config, 'minimal_uploads')
+    minimal = config.getoption('minimal_uploads')
     if minimal:
         data = _sanitize(data)
     resp = requests.post('%s/result' % url, json={'id': env['config']['id'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -567,7 +567,6 @@ def _upload_report(config, data):
 
     url = config.getoption('server_url')
     minimal = _get_bool_option(config, 'minimal_uploads')
-    print('Minimal: %s' % minimal)
     if minimal:
         data = _sanitize(data)
     resp = requests.post('%s/result' % url, json={'id': env['config']['id'],


### PR DESCRIPTION
`store_true` for argparse doesn't actually look at value, only at presence,so `--option=false` is the same as `--option` and `--option=true`.

`store` only stores strings, so tests like `if minimal` would succeed for `--minimal-uploads=false`.