### PR TITLE
Adding release instructions

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -58,3 +58,21 @@ where `<port>` is a port number to start the HTTP server on.
 When developing the web site, a convenient script is `web/watch.sh`, which can
 monitor the source directories and re-build when files are modified. This
 requires `inotify` which may or may not be available on your platform.
+
+
+### Release process
+
+Here are the steps for putting out a fresh release to Pypi.
+
+1. Create a new branch from main, and make release specific updates:
+    * Update `src/psij/version.py` to the new version number
+
+2. Use the standard PR process and get changes from the above step merged to main.
+
+3. Follow instructions here to [pypi docs](https://pypi.org/help/#apitoken) to
+   setup tokens on your machine.
+
+4. Run `make VERSION="version string" tag-and-release`. This will:
+    1. Create and push tags to github
+    2. Build the package
+    3. Push built package to Pypi.


### PR DESCRIPTION
This is one potential release process, that gives you some guarantees of clean history given the volume of activity. I suspect that this might need some discussion before we are agreed on this.

Once this goes in, we can discuss whether it makes sense to do further automation, say once a tag is minted of a regex pattern, github action will do the push to pypi. I'm unsure of how safe this is because the multi-site testing infrastructure is completely separate from github actions and might need some human intervention to confirm everything is green.