### PR TITLE
Adds a test that re-attaches a job, but to another executor instance …

### DIFF
--- a/tests/_test_tools.py
+++ b/tests/_test_tools.py
@@ -38,8 +38,9 @@ def assert_completed(job: Job, status: Optional[JobStatus]) -> None:
                              % (status.message, stdout, stderr))
 
 
-def _get_executor_instance(ep: ExecutorTestParams, job: Job) -> JobExecutor:
-    assert job.spec is not None
-    job.spec.launcher = ep.launcher
-    job.spec.attributes = JobAttributes(custom_attributes=ep.custom_attributes)
+def _get_executor_instance(ep: ExecutorTestParams, job: Optional[Job] = None) -> JobExecutor:
+    if job is not None:
+        assert job.spec is not None
+        job.spec.launcher = ep.launcher
+        job.spec.attributes = JobAttributes(custom_attributes=ep.custom_attributes)
     return JobExecutor.get_instance(ep.executor, url=ep.url)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -32,17 +32,19 @@ def test_simple_job_redirect(execparams: ExecutorTestParams) -> None:
 
 
 def test_attach(execparams: ExecutorTestParams) -> None:
-    job = Job(JobSpec(executable='/bin/sleep', arguments=['1']))
-    ex = _get_executor_instance(execparams, job)
-    ex.submit(job)
-    job.wait(target_states=[JobState.ACTIVE, JobState.COMPLETED])
-    native_id = job.native_id
+    job1 = Job(JobSpec(executable='/bin/sleep', arguments=['1']))
+    ex = _get_executor_instance(execparams, job1)
+    ex.submit(job1)
+    job1.wait(target_states=[JobState.ACTIVE, JobState.COMPLETED])
+    native_id = job1.native_id
 
     assert native_id is not None
     job2 = Job()
     ex.attach(job2, native_id)
-    status = job2.wait(timeout=_get_timeout(execparams))
-    assert_completed(job2, status)
+    status2 = job2.wait(timeout=_get_timeout(execparams))
+    assert_completed(job2, status2)
+    status1 = job1.wait(timeout=_get_timeout(execparams))
+    assert_completed(job1, status1)
 
 
 def test_attach2(execparams: ExecutorTestParams) -> None:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -45,6 +45,21 @@ def test_attach(execparams: ExecutorTestParams) -> None:
     assert_completed(job2, status)
 
 
+def test_attach2(execparams: ExecutorTestParams) -> None:
+    job = Job(JobSpec(executable='/bin/sleep', arguments=['1']))
+    ex = _get_executor_instance(execparams, job)
+    ex.submit(job)
+    job.wait(target_states=[JobState.ACTIVE, JobState.COMPLETED])
+    native_id = job.native_id
+
+    assert native_id is not None
+    job2 = Job()
+    ex2 = _get_executor_instance(execparams)
+    ex2.attach(job2, native_id)
+    status = job2.wait(timeout=_get_timeout(execparams))
+    assert_completed(job2, status)
+
+
 def test_cancel(execparams: ExecutorTestParams) -> None:
     job = Job(JobSpec(executable='/bin/sleep', arguments=['60']))
     ex = _get_executor_instance(execparams, job)


### PR DESCRIPTION
…than

the one used to create the job in the first place.