### PR TITLE
Downgrading flake8 to 5.x since 6.x messed up and is producing F401

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@
 # Testing / QA
 -r requirements-tests.txt
 mypy >=0.931
-flake8
+flake8==5.0.4
 flake8-docstrings
 autopep8
 types-requests


### PR DESCRIPTION
errors for things used in type annotations and docstrings.