### PR TITLE
Docs selectors for testing

### DIFF
--- a/docs/README-selectors.md
+++ b/docs/README-selectors.md
@@ -26,6 +26,15 @@ selector. The string `"<&executor-type>"` must be a standalone token as
 far as the syntax highlighter is concerned. That is, it probably won't
 work if it's in a comment.
 
+An alternative string to `"<&executor-type>"` is `execparams.executor`.
+This so that one could have statements of the form
+
+    x = f(execparams.executor)
+
+works with the selector mechanism. This would allow rendering of
+verbatim functional test cases that parametrize the executor types and
+representing them with selectors in the documentation.
+
 To add alternative code blocks, use:
 
 ```Sphinx

--- a/docs/_static/extras.js
+++ b/docs/_static/extras.js
@@ -59,11 +59,27 @@ function detectAll(selectorType) {
     // Similarly, if "D" is selected in the second selector, we only want to change 
     // simple_value_2. However, if either "B" or "C" are selected in either selector,
     // we want to change both.
-    
+
+    console.log("type:" + selectorType);
     $("p." + selectorType + "-selector").addClass(selectorType + "-item");
+    var prevSpans = [];
     $("span").each(function() {
-        if ($(this).text() == '"<&' + selectorType + '>"') {
+        var text = $(this).text();
+        // look for both "<&<type>>" and execparams.<type> to align with test cases
+
+        if (text == '"<&' + selectorType + '>"') {
             $(this).addClass(selectorType + "-item").addClass("psij-selector-value");
+        }
+        if (text == "executor" && prevSpans.length == 2
+            && prevSpans[0].text() == "execparams" && prevSpans[1].text() == '.') {
+            // remove <span>execparams</span> and <span>.</span>
+            prevSpans[0].remove();
+            prevSpans[1].remove();
+            $(this).addClass(selectorType + "-item").addClass("psij-selector-value");
+        }
+        prevSpans.push($(this));
+        if (prevSpans.length > 2) {
+            prevSpans.shift();
         }
     });
 }

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -80,7 +80,7 @@ Local // Slurm // LSF // PBS // Cobalt
 
     from psij import Job, JobExecutor, JobSpec
 
-    ex = JobExecutor.get_instance("<&executor-type>")
+    ex = JobExecutor.get_instance(execparams.executor)
     job = Job(JobSpec(executable="/bin/date"))
     ex.submit(job)
 

--- a/tests/test_getting_started_docs.py
+++ b/tests/test_getting_started_docs.py
@@ -1,0 +1,72 @@
+"""Functions for testing the various code snippets available in psij docs - 'getting started'."""
+from time import sleep
+from psij import Job, JobSpec, JobStatus
+from executor_test_params import ExecutorTestParams
+from _test_tools import _get_executor_instance, _get_timeout, assert_completed
+
+status_callback_job_count = 3
+
+
+def test_getting_started_basic_usage(execparams: ExecutorTestParams) -> None:
+    job = Job(
+        JobSpec(
+            executable="/bin/date",
+            launcher=execparams.launcher
+        )
+    )
+    ex = _get_executor_instance(execparams, job)
+    ex.submit(job)
+    status = job.wait(timeout=_get_timeout(execparams))
+    assert_completed(job, status)
+
+
+def test_getting_started_adding_complexity(execparams: ExecutorTestParams) -> None:
+    num_jobs = 3
+    for _ in range(num_jobs):
+        job = Job(
+            JobSpec(
+                executable="/bin/date",
+                launcher=execparams.launcher
+            )
+        )
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+
+
+def test_getting_started_status_callbacks(execparams: ExecutorTestParams) -> None:
+    def callback(job: Job, status: JobStatus) -> None:
+        global status_callback_job_count
+        if status.final:
+            print(f"Job {job} completed with status {status}")
+            status_callback_job_count -= 1
+
+    for _ in range(status_callback_job_count):
+        job = Job(JobSpec(executable='/bin/date', launcher=execparams.launcher))
+        ex = _get_executor_instance(execparams, job)
+        ex.set_job_status_callback(callback)
+        ex.submit(job)
+
+    while status_callback_job_count > 0:
+        sleep(0.01)
+
+
+def test_our_test(execparams: ExecutorTestParams) -> None:
+    num_jobs = 3
+
+    def make_job() -> Job:
+        job = Job()
+        spec = JobSpec()
+        spec.executable = 'echo'
+        spec.arguments = ['HELLO WORLD!']
+        job.spec = spec
+        return job
+
+    jobs = []
+    for _ in range(num_jobs):
+        job: Job = make_job()
+        jobs.append(job)
+        jex = _get_executor_instance(execparams, job)
+        jex.submit(job)
+
+    for job in jobs:
+        job.wait()


### PR DESCRIPTION
This basically also allows references of the form `execparams.executor` to be substituted using selectors. That, in turn, would
allow one to include test cases verbatim while preserving the selector behavior. 