### PR TITLE
Upgrade flake8 use typedecl

### DIFF
--- a/docs/README-selectors.md
+++ b/docs/README-selectors.md
@@ -26,6 +26,15 @@ selector. The string `"<&executor-type>"` must be a standalone token as
 far as the syntax highlighter is concerned. That is, it probably won't
 work if it's in a comment.
 
+An alternative string to `"<&executor-type>"` is `execparams.executor`.
+This so that one could have statements of the form
+
+    x = f(execparams.executor)
+
+works with the selector mechanism. This would allow rendering of
+verbatim functional test cases that parametrize the executor types and
+representing them with selectors in the documentation.
+
 To add alternative code blocks, use:
 
 ```Sphinx

--- a/docs/_static/extras.js
+++ b/docs/_static/extras.js
@@ -59,11 +59,27 @@ function detectAll(selectorType) {
     // Similarly, if "D" is selected in the second selector, we only want to change 
     // simple_value_2. However, if either "B" or "C" are selected in either selector,
     // we want to change both.
-    
+
+    console.log("type:" + selectorType);
     $("p." + selectorType + "-selector").addClass(selectorType + "-item");
+    var prevSpans = [];
     $("span").each(function() {
-        if ($(this).text() == '"<&' + selectorType + '>"') {
+        var text = $(this).text();
+        // look for both "<&<type>>" and execparams.<type> to align with test cases
+
+        if (text == '"<&' + selectorType + '>"') {
             $(this).addClass(selectorType + "-item").addClass("psij-selector-value");
+        }
+        if (text == "executor" && prevSpans.length == 2
+            && prevSpans[0].text() == "execparams" && prevSpans[1].text() == '.') {
+            // remove <span>execparams</span> and <span>.</span>
+            prevSpans[0].remove();
+            prevSpans[1].remove();
+            $(this).addClass(selectorType + "-item").addClass("psij-selector-value");
+        }
+        prevSpans.push($(this));
+        if (prevSpans.length > 2) {
+            prevSpans.shift();
         }
     });
 }

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -80,7 +80,7 @@ Local // Slurm // LSF // PBS // Cobalt
 
     from psij import Job, JobExecutor, JobSpec
 
-    ex = JobExecutor.get_instance("<&executor-type>")
+    ex = JobExecutor.get_instance(execparams.executor)
     job = Job(JobSpec(executable="/bin/date"))
     ex.submit(job)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@
 # Testing / QA
 -r requirements-tests.txt
 mypy >=0.931
-flake8==5.0.4
+flake8
 flake8-docstrings
 autopep8
 types-requests

--- a/src/psij/_plugins.py
+++ b/src/psij/_plugins.py
@@ -62,8 +62,8 @@ def _register_plugin(desc: Descriptor, root_path: str, type: str,
     if desc.name not in store:
         store[desc.name] = []
     existing = store[desc.name]
-    entry = _VersionEntry(desc.version, desc_path=desc.path, plugin_path=mod_path,
-                          ecls=cls, exc=exc)  # type: _VersionEntry[T]
+    entry: _VersionEntry[T] = _VersionEntry(desc.version, desc_path=desc.path,
+                                            plugin_path=mod_path, ecls=cls, exc=exc)
     # check if an object with this version already exists
     index = bisect_left(existing, entry)
     if index != len(existing) and existing[index].version == desc.version:

--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -33,13 +33,13 @@ def _attrs_to_mustache(job: Job) -> Dict[str, Union[object, List[Dict[str, objec
     if not job.spec.attributes or not job.spec.attributes._custom_attributes:
         return {}
 
-    r = {}  # type: Dict[str, Union[object, List[Dict[str, object]]]]
+    r: Dict[str, Union[object, List[Dict[str, object]]]] = {}
 
     for k, v in job.spec.attributes._custom_attributes.items():
         ks = k.split('.', maxsplit=1)
         if len(ks) == 2:
             if ks[0] not in r:
-                r[ks[0]] = []  # type[List[Dict[str, object]]
+                r[ks[0]] = []
             cast(List[Dict[str, object]], r[ks[0]]).append({'key': ks[1], 'value': v})
         else:
             r[k] = v
@@ -563,7 +563,7 @@ class _QueuePollThread(Thread):
         self.config = config
         self.executor = executor
         # native_id -> job
-        self._jobs = {}  # type: Dict[str, List[Job]]
+        self._jobs: Dict[str, List[Job]] = {}
         # counts consecutive errors while invoking qstat or equivalent
         self._poll_error_count = 0
         self._jobs_lock = RLock()

--- a/src/psij/executors/local.py
+++ b/src/psij/executors/local.py
@@ -23,11 +23,11 @@ class _ProcessEntry(ABC):
     def __init__(self, job: Job, executor: 'LocalJobExecutor', launcher: Optional[Launcher]):
         self.job = job
         self.executor = executor
-        self.exit_code = None  # type: Optional[int]
-        self.done_time = None  # type: Optional[float]
-        self.out = None  # type: Optional[str]
+        self.exit_code: Optional[int] = None
+        self.done_time: Optional[float] = None
+        self.out: Optional[str] = None
         self.kill_flag = False
-        self.process = None  # type: Optional[subprocess.Popen[bytes]]
+        self.process: Optional[subprocess.Popen[bytes]] = None
         self.launcher = launcher
 
     @abstractmethod
@@ -80,7 +80,7 @@ class _AttachedProcessEntry(_ProcessEntry):
     def poll(self) -> Tuple[Optional[int], Optional[str]]:
         try:
             assert self.process
-            ec = self.process.wait(timeout=0)  # type: Optional[int]
+            ec: Optional[int] = self.process.wait(timeout=0)
             if ec is None:
                 return 0, None
             else:
@@ -105,7 +105,7 @@ def _get_env(spec: JobSpec) -> Optional[Dict[str, str]]:
 
 
 class _ProcessReaper(threading.Thread):
-    _instance = None  # type: _ProcessReaper
+    _instance: Optional['_ProcessReaper'] = None
     _lock = threading.RLock()
 
     @classmethod
@@ -118,7 +118,7 @@ class _ProcessReaper(threading.Thread):
 
     def __init__(self) -> None:
         super().__init__(name='Local Executor Process Reaper', daemon=True)
-        self._jobs = {}  # type: Dict[Job, _ProcessEntry]
+        self._jobs: Dict[Job, _ProcessEntry] = {}
         self._lock = threading.RLock()
 
     def register(self, entry: _ProcessEntry) -> None:
@@ -137,7 +137,7 @@ class _ProcessReaper(threading.Thread):
             time.sleep(_REAPER_SLEEP_TIME)
 
     def _check_processes(self) -> None:
-        done = []  # type: List[_ProcessEntry]
+        done: List[_ProcessEntry] = []
         for entry in self._jobs.values():
             if entry.kill_flag:
                 entry.kill()

--- a/src/psij/job.py
+++ b/src/psij/job.py
@@ -45,11 +45,11 @@ class Job(object):
         self._id = _generate_id()
         self._status = JobStatus(JobState.NEW)
         # need indirect ref to avoid a circular reference
-        self.executor = None  # type: Optional['psij.JobExecutor']
+        self.executor: Optional['psij.JobExecutor'] = None
         # allow the native ID to be anything and do the string conversion in the getter; there's
         # no point in storing integers as strings.
-        self._native_id = None  # type: Optional[object]
-        self._cb = None  # type: Optional[JobStatusCallback]
+        self._native_id: Optional[object] = None
+        self._cb: Optional[JobStatusCallback] = None
         self._status_cv = threading.Condition()
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug('New Job: {}'.format(self))

--- a/src/psij/job_executor.py
+++ b/src/psij/job_executor.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class JobExecutor(ABC):
     """An abstract base class for all JobExecutor implementations."""
 
-    _executors = {}  # type: Dict[str, List[_VersionEntry['JobExecutor']]]
+    _executors: Dict[str, List[_VersionEntry['JobExecutor']]] = {}
 
     def __init__(self, url: Optional[str] = None,
                  config: Optional[JobExecutorConfig] = None):
@@ -40,9 +40,9 @@ class JobExecutor(ABC):
         assert config
         self.config = config
         # _cb is not thread-safe; changing it while jobs are running could lead to badness
-        self._cb = None  # type: Optional[JobStatusCallback]
+        self._cb: Optional[JobStatusCallback] = None
         self._launchers_lock = RLock()
-        self._launchers = {}  # type: Dict[str, Launcher]
+        self._launchers: Dict[str, Launcher] = {}
 
     @property
     def name(self) -> str:

--- a/src/psij/job_launcher.py
+++ b/src/psij/job_launcher.py
@@ -12,7 +12,7 @@ from psij.job import Job
 class Launcher(ABC):
     """An abstract base class for all launchers."""
 
-    _launchers = {}  # type: Dict[str, List[_VersionEntry['Launcher']]]
+    _launchers: Dict[str, List[_VersionEntry['Launcher']]] = {}
     DEFAULT_LAUNCHER_NAME = 'single'
 
     def __init__(self, config: Optional[JobExecutorConfig] = None) -> None:

--- a/src/psij/job_state.py
+++ b/src/psij/job_state.py
@@ -11,7 +11,7 @@ class JobState(bytes, Enum):
 
     def __new__(cls, index: int, order: int, name: str, final: bool) -> 'JobState':  # noqa: D102
         # This is used internally to allow enum initialization with multiple parameters
-        obj = bytes.__new__(cls)  # type: 'JobState'
+        obj: 'JobState' = bytes.__new__(cls)
         obj._value_ = index
         obj._order = order
         obj._name = name
@@ -20,9 +20,9 @@ class JobState(bytes, Enum):
 
     def __init__(self, *args: object) -> None:  # noqa: D107
         # this is only here to declare the types of the properties
-        self._order = self._order  # type: int
-        self._name = self._name  # type: str
-        self._final = self._final  # type: bool
+        self._order: int = self._order
+        self._name: str = self._name
+        self._final: bool = self._final
 
     NEW = (0, 0, 'NEW', False)
     """

--- a/src/psij/launcher.py
+++ b/src/psij/launcher.py
@@ -12,7 +12,7 @@ from psij.job import Job
 class Launcher(ABC):
     """An abstract base class for all launchers."""
 
-    _launchers = {}  # type: Dict[str, List[_VersionEntry['Launcher']]]
+    _launchers: Dict[str, List[_VersionEntry['Launcher']]] = {}
     DEFAULT_LAUNCHER_NAME = 'single'
 
     def __init__(self, config: Optional[JobExecutorConfig] = None) -> None:

--- a/tests/executor_test_params.py
+++ b/tests/executor_test_params.py
@@ -18,11 +18,11 @@ class ExecutorTestParams:
         spec_l = re.split(':', spec, maxsplit=2)
         self.executor = spec_l[0]
         if len(spec_l) > 1:
-            self.launcher = spec_l[1]  # type: Optional[str]
+            self.launcher: Optional[str] = spec_l[1]
         else:
             self.launcher = None
         if len(spec_l) == 3:
-            self.url = spec_l[2]  # type: Optional[str]
+            self.url: Optional[str] = spec_l[2]
         else:
             self.url = None
 

--- a/tests/test_getting_started_docs.py
+++ b/tests/test_getting_started_docs.py
@@ -1,0 +1,72 @@
+"""Functions for testing the various code snippets available in psij docs - 'getting started'."""
+from time import sleep
+from psij import Job, JobSpec, JobStatus
+from executor_test_params import ExecutorTestParams
+from _test_tools import _get_executor_instance, _get_timeout, assert_completed
+
+status_callback_job_count = 3
+
+
+def test_getting_started_basic_usage(execparams: ExecutorTestParams) -> None:
+    job = Job(
+        JobSpec(
+            executable="/bin/date",
+            launcher=execparams.launcher
+        )
+    )
+    ex = _get_executor_instance(execparams, job)
+    ex.submit(job)
+    status = job.wait(timeout=_get_timeout(execparams))
+    assert_completed(job, status)
+
+
+def test_getting_started_adding_complexity(execparams: ExecutorTestParams) -> None:
+    num_jobs = 3
+    for _ in range(num_jobs):
+        job = Job(
+            JobSpec(
+                executable="/bin/date",
+                launcher=execparams.launcher
+            )
+        )
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+
+
+def test_getting_started_status_callbacks(execparams: ExecutorTestParams) -> None:
+    def callback(job: Job, status: JobStatus) -> None:
+        global status_callback_job_count
+        if status.final:
+            print(f"Job {job} completed with status {status}")
+            status_callback_job_count -= 1
+
+    for _ in range(status_callback_job_count):
+        job = Job(JobSpec(executable='/bin/date', launcher=execparams.launcher))
+        ex = _get_executor_instance(execparams, job)
+        ex.set_job_status_callback(callback)
+        ex.submit(job)
+
+    while status_callback_job_count > 0:
+        sleep(0.01)
+
+
+def test_our_test(execparams: ExecutorTestParams) -> None:
+    num_jobs = 3
+
+    def make_job() -> Job:
+        job = Job()
+        spec = JobSpec()
+        spec.executable = 'echo'
+        spec.arguments = ['HELLO WORLD!']
+        job.spec = spec
+        return job
+
+    jobs = []
+    for _ in range(num_jobs):
+        job: Job = make_job()
+        jobs.append(job)
+        jex = _get_executor_instance(execparams, job)
+        jex.submit(job)
+
+    for job in jobs:
+        job.wait()


### PR DESCRIPTION
flake8 6.0.0 (and corresponding pyflakes) removed support for `# type: abc`, which caused unused import errors. The solution was to change those type declarations to the "proper" format (`var: <type> = <value>`).