### PR TITLE
More ghpages fixes

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -48,8 +48,8 @@ Make sure that `build.sh` is called from the main directory. The output will
 be in `web-build`.
 
 3. Render the web site and themed documentation, which can be done using Jekyll.
-To install Jekyll, follow these
-[instructions](https://jekyllrb.com/docs/installation/). Then run
+To install Jekyll, follow the instructions in step 2 of 
+[web/README.md](web/README.md). You only need to do this once. Then run
 
     ```
     web/serve.sh

--- a/web/Gemfile
+++ b/web/Gemfile
@@ -7,7 +7,10 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.3.1"
+
+#gem "jekyll", "~> 4.3.1"
+gem "github-pages", "~> 228", group: :jekyll_plugins
+
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and

--- a/web/README.md
+++ b/web/README.md
@@ -22,7 +22,18 @@ PSI/J repository.
     $ sudo pip install -r requirements-docs.txt
     ```
 
- 2. Install Jekyll (see [Jekyll Installation](https://jekyllrb.com/docs/installation/) - also a one-time operation).
+ 2. Install Jekyll prerequisites by following the instructions for your
+ operating system found in the 
+ [Jekyll installation instructions](https://jekyllrb.com/docs/installation/).
+ You should skip installing Jekyll itself, since it will be installed by 
+ *bundler*. Then run
+    ```bash
+    $ cd web
+    $ bundle update
+    $ cd ..
+    ```
+ to install the version of Jekyll used by github-pages. This is a one-time
+ operation. For subsequent builds, you can skip directly to step 3.
 
  3. Run the build script, which will build the documentation, process
  files in the `web` directory, and generate the output in `web-build`:

--- a/web/_config.yml
+++ b/web/_config.yml
@@ -53,5 +53,15 @@ plugins:
 #   - vendor/gems/
 #   - vendor/ruby/
 
+exclude:
+    - Gemfile
+    - Gemfile.lock
+    - .gitignore
+    - README.md
 include:
-    - "**"
+    - _static
+    - _images
+    - _sources
+    - _modules
+    - .generated
+    - .doctrees


### PR DESCRIPTION
The previous incantation of the web stuff used the latest version of Jekyll. However, gh-pages uses an older version, and that conflicts with the supplied gemfile. Additionally, it processes the configuration (includes/excludes) differently, so this PR also updates the jekyll configuration file.

And last, this updates the relevant README files to reflect the changes above.