### PR TITLE
Fix text squeezing on large displays.

### DIFF
--- a/web/docs/_static/cloud.css
+++ b/web/docs/_static/cloud.css
@@ -106,9 +106,9 @@ div.body {
     line-height: 1.5em;
     padding: 30px 20px;
     min-width: 0;
-    max-width: 8in;
+    max-width: calc(8in + max((100% - 14in) / 2, 8pt));
     border-left: 1px solid var(--color-fg-lines);
-    padding-left: max(calc((100% - 14in) / 2), 8pt);
+    padding-left: calc(max((100% - 14in) / 2, 8pt));
 }
 
 div.sphinxsidebar {


### PR DESCRIPTION
On large displays (with width >>14in), when viewing the documentation pages, the padding kicks in. It is meant to shift the text towards the center while preserving the width of the main text (through the max-width property). However, the padding is part of the width, so it ends up reducing the usable text width.

We could switch to controlling the margin, but then the thin left border also moves, which is unpleasant. I guess we could do that AND have the sidebar draw the border, but that's two steps.

So anyway, this adjusts the max-width to take the padding into account.

This addresses https://github.com/ExaWorks/exaworks.github.io/issues/5

PS: checks fail due to #362