### PR TITLE
Pin typeguard version to 2.xx.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-filelock
-psutil
+filelock==3
+psutil==5
 pystache>=0.6.0
-typeguard
+typeguard==2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-filelock>=3<4
-psutil>=5<6
+filelock~=3.4
+psutil~=5.9
 pystache>=0.6.0
-typeguard>=2<3
+typeguard~=2.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-filelock==3
-psutil==5
+filelock>=3<4
+psutil>=5<6
 pystache>=0.6.0
-typeguard==2
+typeguard>=2<3


### PR DESCRIPTION
Also pins filelock and psutil to known working major versions.

Fixes #362 