### PR TITLE
Some release related updates

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -73,14 +73,17 @@ tab.
 Here are the steps for putting out a fresh release to Pypi.
 
 1. Create a new branch from main and make release specific updates:
-    * Update `src/psij/version.py` to the new version number
+    * Update `RELEASE` and `src/psij/version.py` to the new version number
 
 2. Use the standard PR process and get changes from the above step merged to main.
 
 3. Follow instructions here to [pypi docs](https://pypi.org/help/#apitoken) to
    setup tokens on your machine.
 
-4. Run `make VERSION="version string" tag-and-release`. This will:
+4. Make a clean clone of the main branch
+
+5. Run `make VERSION="version string" tag-and-release`, where the version string
+   has the format "x.y.z[-s]". This will:
     * Create and push tags to GitHub.
     * Build the package.
     * Push built package to Pypi.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,6 @@ master_doc = 'index'
 
 project = u'PSI/J'
 copyright = u'The ExaWorks Team'
-release = u'0.0.1'
-version = release
 
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
@@ -58,6 +56,8 @@ print(src_dir + "/")
 sys.path.insert(0, src_dir)
 
 import psij
+release = psij.__version__
+version = release
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),


### PR DESCRIPTION
Some updated release instructions as well as the docs version using the psij version rather than a manual string.

This PR is a post-release update (i.e., the 0.9 release is done and it does not depend on this PR). However, the online docs still show "0.1.0-post1" as the version until this PR is merged.