### PR TITLE
Fix 404 page (missing tabs property was making it render funny).

### DIFF
--- a/web/404.html
+++ b/web/404.html
@@ -1,11 +1,20 @@
 ---
 permalink: /404.html
 layout: default
+tab: 100
 ---
 
 <div class="container">
-  <h1>404</h1>
+    <div v-if="isDocsPage()">
+        <h1>404</h1>
+        <p><strong>Page not found</strong></p>
+        <p>This version of the documentation does not contain this page. Please go to the <a :href="getMainDocsPage()">main documentation page</a>.
+    </div>
+    <div v-else>
 
-  <p><strong>Page not found :(</strong></p>
-  <p>The requested page could not be found.</p>
+        <h1>404</h1>
+
+        <p><strong>Page not found</strong></p>
+        <p>The requested page could not be found.</p>
+    </div>
 </div>

--- a/web/_includes/vueinit.html
+++ b/web/_includes/vueinit.html
@@ -9,7 +9,9 @@
             },
             methods: {
                 getSortedVersionLabels: getSortedVersionLabels,
-                setVersion: setVersion
+                setVersion: setVersion,
+                getMainDocsPage: getMainDocsPage,
+                isDocsPage: isDocsPage
             }
         });
 

--- a/web/versioning.js
+++ b/web/versioning.js
@@ -219,13 +219,31 @@ function setVersion() {
  *                     currently displayed documentation version.
  */
 function getCurrentVersion() {
-    v = splitLocation()[1];
+    var v = splitLocation()[1];
     if (v == "") {
         return v;
     }
     else {
         return versionSplit(v).version;
     }
+}
+
+/**
+ * Returns the main documentation page for the current version by removing
+ * everything after <code>"../docs/v/x.y.z/"</code> from the current URL.
+ */
+function getMainDocsPage() {
+    var s = splitLocation();
+
+    return s[0] + "/" + s[1] + "/";
+}
+
+/**
+ * Returns true if the current URL points to a versioned documentation
+ * page.
+ */
+function isDocsPage() {
+    return window.location.href.includes("/docs/v/");
 }
 
 initVersions();


### PR DESCRIPTION
Also added code to detect if the 404 is on a documentation page. The version switcher in the documentation attempts to preserve the path (so that if you are looking at, say, JobExecutor in a version, you'd also potentially be looking at JobExecutor after the switch). However, there is no guarantee that the docs structure is the same in the two versions, so you may land on a page that's not there. The code looks at whether you are hitting a 404 on a docs page and offers a link to the main docs page for that version.

Also, a minor fix in `getCurrentVersion`