### PR TITLE
Llnl edits

### DIFF
--- a/QuickStart.md
+++ b/QuickStart.md
@@ -1,23 +1,23 @@
 # Quick Start Guide
 
-This document will guide you through the install procedure and your first hello world example.
+This document will guide you through the install procedure and your first Hello World example.
 
 - [Requirements](#requirements)
-- [Install psij](#install-psij)
+- [Install PSI/J](#install-psij)
 - [Hello World example](#hello-world)
 
 ## Requirements
 - python3.7+
 
-## Install psij
+## Install PSI/J
 
-If you have conda installed you might want to start from a fresh environment. This part is not installing psij but setting up a new environment with the specified python version:
+If you have conda installed you might want to start from a fresh environment. This part is not installing PSI/J but setting up a new environment with the specified python version:
 
 1. `conda create -n psij python=3.7`
 2. `conda activate psij`
 
 
-Install psij from the GitHub repository:
+Install PSI/J from the GitHub repository:
 
 1. Clone the repository into your working directory:
 

--- a/README-dev.md
+++ b/README-dev.md
@@ -68,7 +68,7 @@ web site. The themed documentation will be found under the "Documentation"
 tab.
 
 
-### Release Process
+## Release Process
 
 Here are the steps for putting out a fresh release to Pypi.
 

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,6 +1,4 @@
-# Low Level Development Stuff
-
-## Building the Documentation
+# Building the Documentation
 
 There are two ways to build the documentation. One is the plain one, where
 the plain Sphinx output is desired, and the other is the themed version that
@@ -13,7 +11,7 @@ is meant to integrate with the website.
     resulting pages, such as pages being cut off at the bottom. Please use
     a simple http server as detailed below.
 
-### Building the Standalone Documentation
+## Building the Standalone Documentation
 
 1. Make sure you have the documentation dependencies installed:
     ```sh
@@ -28,7 +26,7 @@ is meant to integrate with the website.
 The output will be in `docs/.build`
 
 
-### Building the Themed Documentation
+## Building the Themed Documentation
 
 This builds the themed version of the docs as well as the website. The steps
 are:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,13 +5,13 @@ The most important classes in this library are ``Job`` and ``JobExecutor``,
 followed by ``Launcher``.
 
 The Job Class and Its Modifiers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------
 
 The Job-related classes listed in this section (``Job``, ``JobSpec``,
 ``ResourceSpec``, and ``JobAttributes``) are independent of
 executor implementations. The authors strongly recommend that users
 program against these classes rather than adding executor-specific
-configuration options, to the extent possible.
+configuration options.
 
 .. autoclass:: psij.Job
     :members:
@@ -26,10 +26,10 @@ configuration options, to the extent possible.
     :noindex:
 
 Job Modifiers
-^^^^^^^^^^^^^
+----------------
 
 There can be a lot of configuration information that goes into each
-resource manager job. Its walltime, partition/queue, the number of nodes
+resource manager job, including its walltime, partition/queue, the number of nodes
 it needs, what kind of nodes, what quality of service the job requires, and
 so on.
 
@@ -53,7 +53,7 @@ scheduling policies.
 .. _executors:
 
 Executors
-~~~~~~~~~
+----------------
 
 Executors are concrete implementations of mechanisms that execute jobs.
 To get an instance of a specific executor, call
@@ -87,7 +87,7 @@ terminal:
 
 
 JobExecutor Base Class
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 The ``psij.JobExecutor`` class is abstract, but offers concrete static methods
 for registering, fetching, and listing subclasses of itself.
@@ -99,43 +99,43 @@ The concrete executor implementations provided by this version of PSI/J Python
 are:
 
 Cobalt
-^^^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.executors.batch.cobalt.CobaltJobExecutor
     :noindex:
 
 Flux
-^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.executors.flux.FluxJobExecutor
     :noindex:
 
 LSF
-^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.executors.batch.lsf.LsfJobExecutor
     :noindex:
 
 PBS
-^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.executors.batch.pbspro.PBSProJobExecutor
     :noindex:
 
 Slurm
-^^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.executors.batch.slurm.SlurmJobExecutor
     :noindex:
 
 Local
-^^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.executors.local.LocalJobExecutor
     :noindex:
 
 Radical Pilot
-^^^^^^^^^^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.executors.rp.RPJobExecutor
     :noindex:
@@ -144,13 +144,15 @@ Radical Pilot
 
 
 Launchers
-~~~~~~~~~
+----------------
 
 Launchers are mechanisms to start the actual jobs on batch schedulers
 once a set of nodes has been allocated for the job. In essence, launchers
 are wrappers around the job executable which can provide additional
 features, such as setting up an MPI environment, starting a copy of the
-job executable on each allocated node, etc. To get a launcher instance,
+job executable on each allocated node, etc. 
+
+To get a launcher instance,
 call :meth:`Launcher.get_instance(name) <psij.launcher.Launcher.get_instance>`
 with ``name`` being the name of a launcher. Like job executors,
 launchers are plugins and can come from various places. To obtain a list
@@ -172,49 +174,49 @@ concrete static methods for registering and fetching subclasses of itself.
 The PSI/J Python library comes with a core set of launchers, which are:
 
 aprun
-^^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.launchers.aprun.AprunLauncher
     :members:
     :noindex:
 
 jsrun
-^^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.launchers.jsrun.JsrunLauncher
     :members:
     :noindex:
 
 srun
-^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.launchers.srun.SrunLauncher
     :members:
     :noindex:
 
 mpirun
-^^^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.launchers.mpirun.MPILauncher
     :members:
     :noindex:
 
 single
-^^^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.launchers.single.SingleLauncher
     :members:
     :noindex:
 
 multiple
-^^^^^^^^
+""""""""""""""""""""""
 
 .. autoclass:: psij.launchers.multiple.MultipleLauncher
     :members:
     :noindex:
 
 Other Package Contents
-~~~~~~~~~~~~~~~~~~~~~~
+----------------
 
 .. automodule:: psij.exceptions
     :members:
@@ -222,8 +224,7 @@ Other Package Contents
 
 
 API Reference
-~~~~~~~~~~~~~
-
+----------------
 .. toctree::
 
     .generated/modules

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,7 +5,7 @@ The most important classes in this library are ``Job`` and ``JobExecutor``,
 followed by ``Launcher``.
 
 The Job Class and Its Modifiers
-----------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Job-related classes listed in this section (``Job``, ``JobSpec``,
 ``ResourceSpec``, and ``JobAttributes``) are independent of
@@ -26,7 +26,7 @@ configuration options.
     :noindex:
 
 Job Modifiers
-----------------
+^^^^^^^^^^^^^
 
 There can be a lot of configuration information that goes into each
 resource manager job, including its walltime, partition/queue, the number of nodes
@@ -53,7 +53,7 @@ scheduling policies.
 .. _executors:
 
 Executors
-----------------
+~~~~~~~~~
 
 Executors are concrete implementations of mechanisms that execute jobs.
 To get an instance of a specific executor, call

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -78,7 +78,7 @@ Rather than:
 Executors can be
 installed from multiple sources, so the precise list of executors
 available to a specific installation of the PSI/J Python library can vary.
-In order to get a list of available executors, you can run, in a
+To get a list of available executors, run the following in a
 terminal:
 
 .. code-block:: shell

--- a/docs/development/programming.rst
+++ b/docs/development/programming.rst
@@ -11,15 +11,15 @@ which should be read first.
 
 The PSI/J specification splits implementations into two main parts:
 
-    - The core classes, containing scheduler-agnostic code. Client code, wanting
+    - **Core classes** containing scheduler-agnostic code. Client code,
       to maintain portability, should only directly reference the core classes.
-    - Executors and launchers, which are specific to scheduler implementations
+    - **Executors and launchers**, which are specific to scheduler implementations
       and can be used interchangeably, provided that the underlying scheduler or
       launcher implementation exists.
 
 Nearly all of the core classes described in the PSI/J Specification are simple
 property containers and the behavior of the few exceptions is thoroughly
-documented therein. There are, however, a few areas that are specific to the
+documented therein. There are, however, a few areas specific to the
 current PSI/J Python implementation which are mostly a matter of implementation
 and are not documented by the specification. These are:
 
@@ -74,8 +74,8 @@ register the executor.
 
 If an error occurs after a descriptor is loaded but before the actual executor
 or launcher class is loaded, that error is stored. Successive attempts to
-instantiate that executor/launcher using
-:meth:`~psij.job_executor.JobExecutor.get_instance` or
+instantiate that executor using
+:meth:`~psij.job_executor.JobExecutor.get_instance` or launcher using
 :meth:`~psij.job_launcher.Launcher.get_instance` will result in the
 stored exception being raised. This prevents packages with broken
 implementations of executors or launchers from reporting errors unless there
@@ -93,7 +93,7 @@ a Local Resource Manager (LRM) that allows job submission by pointing a
 *submit* command (a tool accessible through a standard POSIX `exec()`) to a
 file that contains all relevant job information. It also assumes that there
 exist commands for cancelling the job and for querying for the status of one
-or more jobs previously submitted.
+or more previously submitted jobs.
 
 The general workflow used by the batch scheduler executor to submit a job is as
 follows:
@@ -104,7 +104,7 @@ follows:
     the `name` of the implementing class. The submit script is generated using
     the
     :meth:`~psij.executors.batch.batch_scheduler_executor.BatchSchedulerExecutor.generate_submit_script`
-    method of the implementing class.
+    method of the implementing class. 
 
     2. Execute the command returned by
     :meth:`~psij.executors.batch.batch_scheduler_executor.BatchSchedulerExecutor.get_submit_command` to
@@ -150,7 +150,7 @@ launchers. Consequently, launcher scripts also take care of redirecting the
 standard streams of the actual launcher tool, which is assumed to properly
 aggregate the output streams of the job ranks.
 
-In addition to the functions above, PSI/J launchers also take care of invoking
+In addition to the functions above, PSI/J launchers also invoke
 the pre- and post-launch scripts.
 
 Since script based launchers are interchangeable, they must have a well

--- a/docs/development/tutorial_add_executor.rst
+++ b/docs/development/tutorial_add_executor.rst
@@ -27,7 +27,7 @@ For example, with PBS `qsub` and `qstat` commands are used to submit a request a
 To use BatchSchedulerExecutor for a new local resource manager that uses this command line interface, subclass BatchSchedulerExecutor and add in code that understands how to form the command lines necessary to submit a request for an allocation and to get allocation status. This tutorial will do that for PBSPro.
 
 Adding an Executor
-----------------
+------------------
 
 First set up a directory structure::
 
@@ -53,7 +53,7 @@ Prerequisites:
 First, we'll build a skeleton that won't work, and see that it doesn't work in the test suite. Then we'll build up to the full functionality.
 
 A Not-implemented Stub
-^^^^^^^^^^^^^^
+----------------------
 
 Add the project directory to the Python path directory::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -40,16 +40,16 @@ plus a bunch of attributes.  Static job attributes such as resource requirements
 are defined by the :class:`JobSpec <psij.job_spec.JobSpec>` at
 creation. Dynamic job attributes such as the :class:`JobState
 <psij.job_state.JobState>` are modified by :class:`JobExecutors
-<psij.job_executor.JobExecutor>` as a Job progresses through its lifecycle.
+<psij.job_executor.JobExecutor>` as a job progresses through its lifecycle.
 
-A :class:`JobExecutor <psij.job_executor.JobExecutor>` represents a specific
-Resource Manager, e.g. Slurm, on which the Job is being executed.  Generally,
-when jobs are submitted, they will be queued for a variable period of time,
-depending on how busy the target machine is. Once a Job is started, its
+A JobExecutor represents a specific
+Resource Manager, e.g. Slurm, on which the job is being executed.  Generally,
+when jobs are submitted, they will be queued
+depending on how busy the target machine is. Once a job is started, its
 executable is launched and runs to completion.
 
-In PSI/J, a Job is submitted by :meth:`JobExecutor.submit(Job)
-<psij.job_executor.JobExecutor.submit>` which permanently binds the Job to that
+In PSI/J, a job is submitted by :meth:`JobExecutor.submit(Job)
+<psij.job_executor.JobExecutor.submit>` which permanently binds the job to that
 executor and submits it to the underlying resource manager.
 
 
@@ -83,7 +83,7 @@ Local // Slurm // LSF // PBS // Cobalt
     job = Job(JobSpec(executable="/bin/date"))
     ex.submit(job)
 
-The ``executable="/bin/date")`` part tells PSI/J that we want the job to run
+The ``executable="/bin/date")`` tells PSI/J that we want the job to run
 the ``/bin/date`` command. Once that command has finished executing
 (which should be almost as soon as the job starts, since ``date`` does very little work)
 the resource manager will mark the job as complete, triggering PSI/J to do the same.
@@ -96,5 +96,5 @@ Up-to-date and actively tested examples can be found
 `here <https://github.com/ExaWorks/psij-python/blob/main/tests/test_doc_examples.py>`_.
 Tests of resource-manager-specific and site-specific values
 (such as accounts, queues/partitions, etc.) can be found in files
-in the same directory but tend to buried under
+in the same directory but tend to be buried under
 layers of indirection in order to reduce code complexity.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -83,7 +83,7 @@ Local // Slurm // LSF // PBS // Cobalt
     job = Job(JobSpec(executable="/bin/date"))
     ex.submit(job)
 
-The ``executable="/bin/date")`` tells PSI/J that we want the job to run
+The ``executable="/bin/date"`` parameter tells PSI/J that we want the job to run
 the ``/bin/date`` command. Once that command has finished executing
 (which should be almost as soon as the job starts, since ``date`` does very little work)
 the resource manager will mark the job as complete, triggering PSI/J to do the same.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,16 +16,16 @@ scheduler. PSI/J has a number of advantages:
 
 #. **Offers an asynchronous modern API for job management.** PSI/J is a clean Python API for requesting and managing jobs that works across a variety of HPC centers.
 
-#. **Supports common batch schedulers.** It's easy to test PSI/J on your systems—including multiple DOE supercomputer centers—and share the results with the community.
+#. **Supports the common batch schedulers:** We test PSI/J across multiple DOE supercomputer centers. It's easy to test PSI/J on your systems and share the results with the community.
 
 #. **Is built by the HPC community, for the HPC community:** PSI/J is based on a number of libraries used by state-of-the-art HPC workflow applications.
 
-#. **Leverages contributor expertise as an open source project:** We are establishing a community to develop, test, and deploy PSI/J across many HPC facilities.
+#. **PSI/J is an open source project:** We are establishing a community to develop, test, and deploy PSI/J across many HPC facilities.
 
 Most HPC centers feature multiple schedulers, rolling policy changes and
 deployments of software stacks, and subtle differences even across systems with
-similar architectures. **PSI/J tames this complexity** for
-computational scientists and workflow developers.
+similar architectures. **PSI/J is designed to tame this complexity** and provide
+computational scientists and workflow developers a common API for interacting
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,26 +8,24 @@ Portable Submission Interface for Jobs (PSI/J) - Python Library
    :align: center
 
 PSI/J provides a modern unified API across different HPC schedulers, enabling
-your HPC application to run virtually anywhere.  PSI/J automatically translates
+your application to run virtually anywhere.  Built by a team with decades of experience building workflow systems for large-scale computing, PSI/J automatically translates
 abstract job specifications into concrete scripts and commands to send to the
-scheduler. PSI/J was built by a team with decades of experience building
-workflow systems for large scale computing. PSI/J has a number of advantages:
+scheduler. PSI/J has a number of advantages:
 
-#. **Runs entirely in user space:** No need to wait for infrequent deployment cycles, it's easy to leverage built-in or commmunity-provided plug-ins.
+#. **Runs entirely in user space.** There's no need to wait for infrequent deployment cycles, it's easy to leverage built-in or commmunity-provided plug-ins.
 
-#. **An asynchronous modern API for job management:** A clean Python API for requesting and managing jobs.
+#. **Offers an asynchronous modern API for job management.** PSI/J is a clean Python API for requesting and managing jobs that works across a variety of HPC centers.
 
-#. **Supports the common batch schedulers:** We test PSI/J across multiple DOE supercomputer centers. It's easy to test PSI/J on your systems and share the results with the community.
+#. **Supports common batch schedulers.** It's easy to test PSI/J on your systems—including multiple DOE supercomputer centers—and share the results with the community.
 
-#. **Built by the HPC community, for the HPC community:** PSI/J is based on a number of libraries used by state-of-the-art HPC workflow applications.
+#. **Is built by the HPC community, for the HPC community:** PSI/J is based on a number of libraries used by state-of-the-art HPC workflow applications.
 
-#. **PSI/J is an open source project:** We are establishing a community to develop, test, and deploy PSI/J across many HPC facilities.
+#. **Leverages contributor expertise as an open source project:** We are establishing a community to develop, test, and deploy PSI/J across many HPC facilities.
 
-Most HPC centers now feature multiple schedulers, rolling policy changes and
+Most HPC centers feature multiple schedulers, rolling policy changes and
 deployments of software stacks, and subtle differences even across systems with
-similar architectures. **PSI/J is designed to tame this complexity** and provide
-computational scientists and workflow developers a common API for interacting
-with HPC centers.
+similar architectures. **PSI/J tames this complexity** for
+computational scientists and workflow developers.
 
 
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -14,7 +14,7 @@ PSI/J simplifies your work.
 
 
 When Not to Use PSI/J
-^^^^^^^^^^^^^^
+-------------------------------
 
 If you are certain that you will only *ever* be launching jobs on ORNL's Summit
 system and you don't care about any other cluster or machine, it makes sense to 
@@ -53,7 +53,7 @@ What is a JobExecutor?
 
 A :class:`JobExecutor <psij.job_executor.JobExecutor>` represents a specific RM,
 e.g. Slurm, on which the job is being executed.  Generally, when jobs are
-submitted they will be queued depending on how
+submitted they will be queued for a variable period of time, depending on how
 busy the target machine is. Once the job is started, its executable is
 launched and runs to completion, and the job will be marked as completed.
 
@@ -81,7 +81,7 @@ reference the `developer documentation
 
 
 Submitting a Job
-------------
+----------------
 
 The most basic way to use PSI/J looks something like the following:
 
@@ -112,7 +112,7 @@ manager’s queue after running the example above.
 
 
 Submitting Multiple Jobs
-^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 In the last section we submitted a single job.  Submitting multiple jobs is as
 simple as adding a loop:
@@ -133,7 +133,7 @@ numbers of jobs (tested with up to 64k jobs).
 Configuring Your Job
 --------------------
 
-In the example above, the ``executable='/bin/date'`` tells PSI/J that we want
+In the example above, ``executable='/bin/date'`` tells PSI/J that we want
 the job to run the ``/bin/date`` command. But there are other parts of the job
 which can be configured:
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -8,28 +8,24 @@ Who PSI/J Is for
 PSI/J is a Python library for submitting and managing HPC jobs via arbitrary
 Resource Managers (RMs). PSI/J abstracts the specific RM, making your code
 RM-independent and portable, or at least easier to port, across HPC centers.  If
-you want your project to be able to request resources from one or more of Slurm,
-LSF, Flux, Cobalt, PBS, and your local machine, we think you will find that
-PSI/J simplifies your work considerably.
+you want your project to request resources from Slurm,
+LSF, Flux, Cobalt, PBS, and/or your local machine, 
+PSI/J simplifies your work.
 
 
-Who PSI/J Is (Probably) Not for
--------------------------------
+When Not to Use PSI/J
+^^^^^^^^^^^^^^
 
-If you are sure that you will only *ever* be launching jobs on ORNL's Summit
-system, and you don't care about any other cluster or machine, then you may as
-well interact with LSF (the resource manager on Summit) directly, rather than
-indirectly through PSI/J. In that case PSI/J would not really be adding much
-other than complexity.
+If you are certain that you will only *ever* be launching jobs on ORNL's Summit
+system and you don't care about any other cluster or machine, it makes sense to 
+interact with LSF (the resource manager on Summit) directly, rather than
+indirectly through PSI/J. 
 
 If you write application code that is meant to run on various HPC clusters, but
 which never makes calls to the underlying resource manager (e.g. by calling into
-Flux's client library, or executing ``srun``/``jsrun``/``aprun`` etc.), then
-PSI/J will not help you. This is likely your situation if you are a developer
-working on a MPI-based science simulation, since we have observed that it is
-often the users' responsibility to actually launch the simulation through the
-resource manager.  However, PSI/J is more likely to help with various tools
-associated with your simulation--for instance, your test suite.
+Flux's client library, or executing ``srun``/``jsrun``/``aprun`` etc.), 
+PSI/J will not help you. However, PSI/J may be helpful when working with various tools
+associated with MPI-based science simulations--for instance, your test suite.
 
 
 Terminology
@@ -57,7 +53,7 @@ What is a JobExecutor?
 
 A :class:`JobExecutor <psij.job_executor.JobExecutor>` represents a specific RM,
 e.g. Slurm, on which the job is being executed.  Generally, when jobs are
-submitted they will be queued for a variable period of time, depending on how
+submitted they will be queued depending on how
 busy the target machine is. Once the job is started, its executable is
 launched and runs to completion, and the job will be marked as completed.
 
@@ -84,7 +80,7 @@ reference the `developer documentation
 <development/tutorial_add_executor.html>`_ for details.
 
 
-Submit a Job
+Submitting a Job
 ------------
 
 The most basic way to use PSI/J looks something like the following:
@@ -94,7 +90,7 @@ The most basic way to use PSI/J looks something like the following:
 3. Create a ``Job`` with that ``JobSpec``.
 4. Submit the ``Job`` instance to the ``JobExecutor``.
 
-On a Slurm cluster, this code might look like:
+Here's how the code might look on different clusters:
 
 .. rst-class:: executor-type-selector selector-mode-tabs
 
@@ -105,7 +101,6 @@ Slurm // Local // LSF // PBS // Cobalt
     :dedent: 4
     :lines: 6-8
 
-And by way of comparison, other backends can be selected with the tabs above.
 Note that the only difference is the argument to the ``get_instance`` method.
 
 The ``JobExecutor`` implementation will translate all PSI/J API activities into the
@@ -116,7 +111,7 @@ Assuming there are no errors, you should see a new entry in your resource
 manager’s queue after running the example above.
 
 
-Multiple Jobs
+Submitting Multiple Jobs
 ^^^^^^^^^^^^^
 
 In the last section we submitted a single job.  Submitting multiple jobs is as
@@ -138,8 +133,8 @@ numbers of jobs (tested with up to 64k jobs).
 Configuring Your Job
 --------------------
 
-In the example above, the ``executable='/bin/date'`` part tells PSI/J that we want
-the job to run the ``/bin/date`` command. But there are other parts to the job
+In the example above, the ``executable='/bin/date'`` tells PSI/J that we want
+the job to run the ``/bin/date`` command. But there are other parts of the job
 which can be configured:
 
 - Arguments for the job executable
@@ -169,7 +164,7 @@ Slurm // Local // LSF // PBS // Cobalt
     :dedent: 4
     :lines: 6-8
 
-Note: `JobSpec` attributes can also be added incrementally:
+`JobSpec` attributes can also be added incrementally:
 
 .. code-block:: python
 
@@ -228,10 +223,10 @@ The number and type of resources are defined by a resource specification,
 ``ResourceSpec``, which becomes part of the job specification.  The resource
 specification supports the following attributes:
 
-  - ``node_count``: Allocate that number of compute nodes to the job.  All
+  - ``node_count``: Allocates that number of compute nodes to the job.  All
     cpu-cores and gpu-cores on the allocated node can be exclusively used by the
     submitted job.
-  - ``processes_per_node``: On the allocated nodes, execute that given number of
+  - ``processes_per_node``: On the allocated nodes, executes that number of
     processes.
   - ``process_count``: The total number of processes (MPI ranks) to be started.
   - ``cpu_cores_per_process``: The number of cpu cores allocated to each launched
@@ -240,8 +235,8 @@ specification supports the following attributes:
   - ``gpu_cores_per_process``: The number of gpu cores allocated to each launched
     process.  The system definition of a gpu core is used, but usually refers
     to a full physical GPU.
-  - ``exclusive_node_use``: When this boolean flag is set to ``True``, then PSI/J
-    will ensure that no other jobs, neither from the same user nor from other users
+  - ``exclusive_node_use``: When this boolean flag is set to ``True``, PSI/J
+    will ensure that no other jobs, whether from the same user nor from other users
     of the same system, will run on any of the compute nodes on which processes
     for this job are launched.
 
@@ -307,9 +302,9 @@ running on.
 Managing Job State
 ------------------
 
-In all the above examples, we have submitted jobs without checking on what
+In the above examples, we submitted jobs without checking on what
 happened to them. Once the job has finished executing (which, for `/bin/date`,
-should be almost as soon as the job starts) the resource manager will mark the
+should be almost as soon as the job starts), the resource manager will mark the
 job as complete, triggering PSI/J to do the same via the :class:`JobStatus
 <psij.job_status.JobStatus>` attribute of the job.  ``Job`` state
 progressions follow this state model:

--- a/web/about.html
+++ b/web/about.html
@@ -16,13 +16,13 @@ tab: 4
                                     Project</a> which brings together a number of high level HPC tools developed
                                 by the members of ExaWorks. We noticed that most of these projects, as well as
                                 many of the community projects, implemented a software layer/library to interact
-                                with HPC schedulers in order to insulate the core functionality from the
-                                details of how things are specified for each scheduler. We also noticed that
-                                the respective libraries mostly covered schedulers running on resources that
-                                each team had access to. We figured that we could use our combined knowledge to
-                                design a single API/library for this goal, a library that would be tested on all
-                                resources that all ExaWorks teams have access to. We could then share this API
-                                and library so that all high level HPC tools could benefit from it.
+                                with HPC schedulers in order to insulate the core functionality from the detailed
+                                scheduler specifications. We also noticed that
+                                the respective libraries were limited to schedulers running on resources that
+                                each team had access to. We used our combined knowledge to
+                                design a single API/library for this goal, one that would be tested on all
+                                resources that all ExaWorks teams have access to. We then shared this API
+                                and library so that all high level HPC tools can benefit from it.
                             </p>
                         </v-card>
 
@@ -30,25 +30,23 @@ tab: 4
                             <h2>The complexity of testing HPC libraries</h2>
 
                             <p>
-                                A major factor contributing to the difficulties in maintaining HPC software
+                                A major difficulty in maintaining HPC software
                                 tools is that access to HPC resources is generally limited to a small number
-                                of clusters local to each team. Additionally, HPC resources tend to vary
-                                widely depending on the institution that maintains them. Consequently, the
-                                chances that software that is tested on resources that a HPC tool development
-                                team has access to will encounter problems on other HPC resources is fairly
-                                high. As mentioned above, a first step in addressing this problem is by
-                                pooling the teams' respective resources for testing purposes. However,
+                                of clusters local to each team. Additionally, HPC resources vary
+                                widely depending on the institution that maintains them. Consequently,
+                                software that is tested on resources that a HPC tool development
+                                team has access to is likely to encounter problems on other HPC resources. A first step in addressing this problem is by
+                                pooling teams' respective resources for testing purposes.
                                 <span class="psij-font">PSI/J</span> takes it a step further by exposing an
                                 infrastructure that allows any user <span class="psij-font">PSI/J</span> user
-                                to easily contribute test results to the <span class="psij-font">PSI/J</span>,
-                                and do so automatically. This is a mutually beneficial relationship: the
-                                <span class="psij-font">PSI/J</span> community at large gains a certain level
-                                of assurance that <span class="psij-font">PSI/J</span> functions correctly on
+                                to easily contribute test results to <span class="psij-font">PSI/J</span>,
+                                and do so automatically. This is mutually beneficial: the
+                                <span class="psij-font">PSI/J</span> community gains assurance that <span class="psij-font">PSI/J</span> functions correctly on
                                 a wide range of resources, while users contributing tests have a mechanism to
                                 ensure that the <span class="psij-font">PSI/J</span> team is aware of
                                 potential problems specific to their resources and can address them, thus
                                 ensuring that <span class="psij-font">PSI/J</span> continues to function
-                                correctly on specific resources.
+                                correctly on those resources.
                             </p>
                         </v-card>
 

--- a/web/about.html
+++ b/web/about.html
@@ -16,9 +16,9 @@ tab: 4
                                     Project</a> which brings together a number of high level HPC tools developed
                                 by the members of ExaWorks. We noticed that most of these projects, as well as
                                 many of the community projects, implemented a software layer/library to interact
-                                with HPC schedulers in order to insulate the core functionality from the detailed
-                                scheduler specifications. We also noticed that
-                                the respective libraries were limited to schedulers running on resources that
+                                with HPC schedulers in order to insulate the core functionality from the
+                                details of how things are specified for each scheduler. We also noticed that
+                                the respective libraries were mostly limited to schedulers running on resources that
                                 each team had access to. We used our combined knowledge to
                                 design a single API/library for this goal, one that would be tested on all
                                 resources that all ExaWorks teams have access to. We then shared this API

--- a/web/index.html
+++ b/web/index.html
@@ -33,13 +33,11 @@ tab: 0
                                         <i class="fas fa-server" style="color: #9A4A68"></i>
                                     </div>
                                     <v-card-title class="text-h5 justify-center">
-                                        Write Scheduler-Agnostic HPC Applications
+                                        Run your HPC application anywhere 
                                     </v-card-title>
 
                                     <v-card-text>
-                                        Use a unified API to run your HPC application virtually anywhere. Tested on a wide variety of clusters,
-                                        <span class="psij-font">PSI/J</span> automatically translates abstract job
-                                        specifications into concrete scripts and commands to send to the scheduler.
+                                      <span class="psij-font>PSI/J</span>’s unified API automatically translates abstract job specs into concrete scripts and commands to send to the scheduler.
                                     </v-card-text>
                                 </v-card>
                             </v-col>
@@ -54,12 +52,10 @@ tab: 0
                             <v-col justify="center">
                                 <v-card align="center">
                                     <div class="icon-logo"><i class="fas fa-terminal" style="color: #DD3D5A"></i></div>
-                                    <h3><span class="psij-font">PSI/J</span> runs entirely in user space</h3>
+                                    <h3>Stay on top of cluster changes </h3>
 
                                     <v-card-text>
-                                        There's no need to wait for infrequent deployment cycles. The HPC world
-                                        is dynamic and the ability to quickly integrate changes
-                                        prompted by experimental changes in the cluster environment is essential.
+                                        Quickly respond to experimental changes in the cluster environment rather than waiting for infrequent deployment cycles. 
                                     </v-card-text>
                                 </v-card>
                             </v-col>
@@ -67,10 +63,10 @@ tab: 0
                                 <v-card align="center">
                                     <div class="icon-logo"><i class="fas fa-puzzle-piece" style="color: #F15A3D"></i>
                                     </div>
-                                    <h3>Use built-in or community-contributed plugins</h3>
+                                    <h3>Leverage a community of coders</h3>
 
                                     <v-card-text>
-                                        <span class="psij-font">PSI/J</span> enables and encourages community contributions to scheduler adapters, testbeds, and cluster knowledge, effectively crowdsourcing stable and tested adapters for a variety of environments.
+                                        Community contributors expand its utility across a variety of clusters with constant extensions and improvements. 
                                     </v-card-text>
                                 </v-card>
                             </v-col>
@@ -78,12 +74,10 @@ tab: 0
                             <v-col justify="center">
                                 <v-card align="center">
                                     <div class="icon-logo"><i class="fas fa-save" style="color: #FDA214"></i></div>
-                                    <h3><span class="psij-font">PSI/J</span> is built on a rich HPC legacy</h3>
+                                    <h3>Rely on a state-of-the-art HPC workflow </h3>
 
                                     <v-card-text>
-                                        <span class="psij-font">PSI/J</span> is based on a number of
-                                        libraries used by state-of-the-art HPC workflow applications. Its architectural
-                                        foundations have been tested by an expert team at extreme scales and in diverse environments.
+                                        <span class="psij-font">PSI/J</span> was built by a team with decades of experience building workflow systems for large scale computing. 
                                     </v-card-text>
                                 </v-card>
                             </v-col>

--- a/web/index.html
+++ b/web/index.html
@@ -33,11 +33,11 @@ tab: 0
                                         <i class="fas fa-server" style="color: #9A4A68"></i>
                                     </div>
                                     <v-card-title class="text-h5 justify-center">
-                                        Run your HPC application anywhere 
+                                        Write Scheduler Agnostic HPC Applications 
                                     </v-card-title>
 
                                     <v-card-text>
-                                      <span class="psij-font>PSI/J</span>’s unified API automatically translates abstract job specs into concrete scripts and commands to send to the scheduler.
+                                      Use a unified API to enable your HPC application to run virtually anywhere.
                                     </v-card-text>
                                 </v-card>
                             </v-col>
@@ -52,10 +52,10 @@ tab: 0
                             <v-col justify="center">
                                 <v-card align="center">
                                     <div class="icon-logo"><i class="fas fa-terminal" style="color: #DD3D5A"></i></div>
-                                    <h3>Stay on top of cluster changes </h3>
+                                    <h3><span class="psij-font">PSI/J</span> runs entirely in user space</h3>
 
                                     <v-card-text>
-                                        Quickly respond to experimental changes in the cluster environment rather than waiting for infrequent deployment cycles. 
+                                        here is no need to wait for infrequent deployment cycles. The HPC world
                                     </v-card-text>
                                 </v-card>
                             </v-col>
@@ -63,10 +63,10 @@ tab: 0
                                 <v-card align="center">
                                     <div class="icon-logo"><i class="fas fa-puzzle-piece" style="color: #F15A3D"></i>
                                     </div>
-                                    <h3>Leverage a community of coders</h3>
+                                    <h3>Use built-in or community contributed plugins</h3>
 
                                     <v-card-text>
-                                        Community contributors expand its utility across a variety of clusters with constant extensions and improvements. 
+                                        It is virtually impossible for a single entity to
                                     </v-card-text>
                                 </v-card>
                             </v-col>
@@ -74,7 +74,7 @@ tab: 0
                             <v-col justify="center">
                                 <v-card align="center">
                                     <div class="icon-logo"><i class="fas fa-save" style="color: #FDA214"></i></div>
-                                    <h3>Rely on a state-of-the-art HPC workflow </h3>
+                                    <h3><span class="psij-font">PSI/J</span> has a rich HPC legacy</h3>
 
                                     <v-card-text>
                                         <span class="psij-font">PSI/J</span> was built by a team with decades of experience building workflow systems for large scale computing. 

--- a/web/index.html
+++ b/web/index.html
@@ -33,14 +33,13 @@ tab: 0
                                         <i class="fas fa-server" style="color: #9A4A68"></i>
                                     </div>
                                     <v-card-title class="text-h5 justify-center">
-                                        Write Scheduler Agnostic HPC Applications
+                                        Write Scheduler-Agnostic HPC Applications
                                     </v-card-title>
 
                                     <v-card-text>
-                                        Use a unified API to enable your HPC application to run virtually anywhere.
+                                        Use a unified API to run your HPC application virtually anywhere. Tested on a wide variety of clusters,
                                         <span class="psij-font">PSI/J</span> automatically translates abstract job
                                         specifications into concrete scripts and commands to send to the scheduler.
-                                        <span class="psij-font">PSI/J</span> is tested on a wide variety of clusters.
                                     </v-card-text>
                                 </v-card>
                             </v-col>
@@ -58,8 +57,8 @@ tab: 0
                                     <h3><span class="psij-font">PSI/J</span> runs entirely in user space</h3>
 
                                     <v-card-text>
-                                        There is no need to wait for infrequent deployment cycles. The HPC world
-                                        tends to be rather dynamic and the ability to quickly integrate changes
+                                        There's no need to wait for infrequent deployment cycles. The HPC world
+                                        is dynamic and the ability to quickly integrate changes
                                         prompted by experimental changes in the cluster environment is essential.
                                     </v-card-text>
                                 </v-card>
@@ -68,14 +67,10 @@ tab: 0
                                 <v-card align="center">
                                     <div class="icon-logo"><i class="fas fa-puzzle-piece" style="color: #F15A3D"></i>
                                     </div>
-                                    <h3>Use built-in or community contributed plugins</h3>
+                                    <h3>Use built-in or community-contributed plugins</h3>
 
                                     <v-card-text>
-                                        Let's be realistic. It is virtually impossible for a single entity to
-                                        provide stable and tested adapters to all clusters and schedulers. That is
-                                        why <span class="psij-font">PSI/J</span> enables and encourages community
-                                        contributions to scheduler adapters, testbeds, and specific cluster
-                                        knowledge.
+                                        <span class="psij-font">PSI/J</span> enables and encourages community contributions to scheduler adapters, testbeds, and cluster knowledge, effectively crowdsourcing stable and tested adapters for a variety of environments.
                                     </v-card-text>
                                 </v-card>
                             </v-col>
@@ -83,13 +78,12 @@ tab: 0
                             <v-col justify="center">
                                 <v-card align="center">
                                     <div class="icon-logo"><i class="fas fa-save" style="color: #FDA214"></i></div>
-                                    <h3><span class="psij-font">PSI/J</span> has a rich HPC legacy</h3>
+                                    <h3><span class="psij-font">PSI/J</span> is built on a rich HPC legacy</h3>
 
                                     <v-card-text>
-                                        The design of <span class="psij-font">PSI/J</span> is based on a number of
-                                        libraries used by state of the art HPC workflow applications that the
-                                        <span class="psij-font">PSI/J</span> team has worked on. Its architectural
-                                        foundations have been tested at extreme scales and in diverse environments.
+                                        <span class="psij-font">PSI/J</span> is based on a number of
+                                        libraries used by state-of-the-art HPC workflow applications. Its architectural
+                                        foundations have been tested by an expert team at extreme scales and in diverse environments.
                                     </v-card-text>
                                 </v-card>
                             </v-col>


### PR DESCRIPTION
Changes are spread across multiple documents. Most are optional but tighten up the language a bit.

**QuickStart.md**
- Standardized spelling/capitalization of PSI/J when not part of code.
- Updated Hello World capitalization

**README-dev.md**
- Line 1: Removed previous h1, which didn't add clarity. This required subsequent changes to other headers (bumping them up a level).

**docs/api.rst**
- Overall: Streamlined content; most edits are optional but tighten up the language a bit.
- Lines 8, 29, 56, 147, 219, 227: Promoted a header to an h2 from an h3.
- Lines 102, 108, 114, 120, 126, 132, 128, 177, 184, 191, 198, 205, 212: Demoted headers from h3s to h4s.

**docs/development/programming.rst**
- Overall: Streamlined content; most edits are optional but tighten up the language a bit.
- Lines 14, 16: Added bolding for skimmability.
- Lines 77-78: Split up executor/launcher mentions to more clearly associate them with the related methods.

**docs/development/tutorial_add_executor.rst** 
- Overall: Streamlined content; most edits are optional but tighten up the language a bit.
- Lines 29-30: Added an h2 to help with content hierarchy/structure.
- Line 56: Demoted a header from an h2 to an h3.

**docs/getting_started.rst**
- Overall: Streamlined content; most edits are optional but tighten up the language a bit.
- Lines 46-52: Standardized capitalization of job for in-text references. Treated in-text references as lowercase and methods as uppercase.

**docs/index.rst**
- Lines 15-23: Rephrased bullets to create parallel structure.
  - Did not adjust language to match the web/index.html page, but it's something to consider. (Alternatively, you might consider whether both versions are needed...)

**docs.user_guide.rst**
- Overall: Streamlined content; most edits are optional but tighten up the language a bit.
- Lines 16-17: Demoted a header to fall beneath the previous discussion point.
- Lines 83, 114: Rephrased bullets to create parallel structure.

**web/about.html**
- Overall: Streamlined content; most edits are optional but tighten up the language a bit.
- Lines 19-25: Used more declarative language (PSI/J does x, rather than we intend PSI/J to do X).

**web/index.html**
**- NOTE: Review these changes closely! I took a lot of liberties in creating "marketing-style" copy—keep what you like and toss the rest.**
  - Please also note that the provided copy will sit in the on-screen boxes nicely. If you need different copy but want it to fit well, let me know and we can review/revise.
