### PR TITLE
Don't hold the reaper lock while checking processes, since it can

### DIFF
--- a/src/psij/executors/local.py
+++ b/src/psij/executors/local.py
@@ -151,7 +151,7 @@ class _ProcessReaper(threading.Thread):
         with self._cvar:
             try:
                 self._cvar.notify_all()
-            except RuntimeError as ex:
+            except RuntimeError:
                 # In what looks like rare cases, notify_all(), seemingly when combined with
                 # signal handling, raises `RuntimeError: release unlocked lock`.
                 # There appears to be an unresolved Python bug about this:

--- a/src/psij/executors/local.py
+++ b/src/psij/executors/local.py
@@ -162,7 +162,7 @@ class _ProcessReaper(threading.Thread):
                 # small delay in processing a completed job. However, since this exception seems
                 # to be a logical impossibility when looking at the code in threading.Condition,
                 # there is really no telling what else could go wrong.
-                logger.warning('Exception in Condition.notify_all()', ex)
+                logger.debug('Exception in Condition.notify_all()')
 
     def _check_processes(self, jobs: Dict[Job, _ProcessEntry]) -> None:
         done: List[_ProcessEntry] = []


### PR DESCRIPTION
stall new jobs from being submitted. Instead, make a copy of the jobs dict and operate on that without holding the lock.

This seems to make the local executor faster (!) than plain Popen + wait, which I can't say I understand clearly.