### PR TITLE
Fix `Install from pip` instruction in getting started page of documentation

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -19,7 +19,7 @@ Install from pip
 
 .. code-block:: console
 
-    pip install psij
+    pip install psij-python
 
 Install from Source
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The current `Install from pip` instruction in the Getting Started page of the documentation is:
```
pip install psij
```
which should instead be:
```
pip install psij-python
```