### PR TITLE
Attach signal handler when starting reaper to avoid starting reaper on

### DIFF
--- a/src/psij/executors/local.py
+++ b/src/psij/executors/local.py
@@ -22,7 +22,6 @@ def _handle_sigchld(signum: int, frame: Optional[FrameType]) -> None:
     _ProcessReaper.get_instance()._handle_sigchld()
 
 
-signal.signal(signal.SIGCHLD, _handle_sigchld)
 _REAPER_SLEEP_TIME = 0.2
 
 
@@ -121,6 +120,7 @@ class _ProcessReaper(threading.Thread):
             if cls._instance is None:
                 cls._instance = _ProcessReaper()
                 cls._instance.start()
+                signal.signal(signal.SIGCHLD, _handle_sigchld)
             return cls._instance
 
     def __init__(self) -> None:


### PR DESCRIPTION
import. It also solves some problems with starting jobs from subprocesses.

However, a better solution for making things work properly in both parent process and subprocesses when fork is involved is to associate singleton threads with process IDs.