### PR TITLE
Proper singleton threads

### DIFF
--- a/src/psij/executors/local.py
+++ b/src/psij/executors/local.py
@@ -18,8 +18,15 @@ from psij import JobExecutor
 logger = logging.getLogger(__name__)
 
 
+if threading.current_thread() != threading.main_thread():
+    raise ImportError('The psij module must be imported from the main thread.')
+
+
 def _handle_sigchld(signum: int, frame: Optional[FrameType]) -> None:
     _ProcessReaper.get_instance()._handle_sigchld()
+
+
+signal.signal(signal.SIGCHLD, _handle_sigchld)
 
 
 _REAPER_SLEEP_TIME = 0.2

--- a/src/psij/executors/local.py
+++ b/src/psij/executors/local.py
@@ -7,13 +7,14 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from types import FrameType
-from typing import Optional, Dict, List, Type, Tuple
+from typing import Optional, Dict, List, Tuple, Type, cast
 
 import psutil
 
 from psij import InvalidJobException, SubmitException, Launcher
 from psij import Job, JobSpec, JobExecutorConfig, JobState, JobStatus
 from psij import JobExecutor
+from psij.utils import SingletonThread
 
 logger = logging.getLogger(__name__)
 
@@ -117,18 +118,11 @@ def _get_env(spec: JobSpec) -> Optional[Dict[str, str]]:
         return spec.environment
 
 
-class _ProcessReaper(threading.Thread):
-    _instance: Optional['_ProcessReaper'] = None
-    _lock = threading.RLock()
+class _ProcessReaper(SingletonThread):
 
     @classmethod
     def get_instance(cls: Type['_ProcessReaper']) -> '_ProcessReaper':
-        with cls._lock:
-            if cls._instance is None:
-                cls._instance = _ProcessReaper()
-                cls._instance.start()
-                signal.signal(signal.SIGCHLD, _handle_sigchld)
-            return cls._instance
+        return cast('_ProcessReaper', super().get_instance())
 
     def __init__(self) -> None:
         super().__init__(name='Local Executor Process Reaper', daemon=True)
@@ -205,8 +199,15 @@ class LocalJobExecutor(JobExecutor):
     This job executor is intended to be used when there is no resource manager, only
     the operating system. Or when there is a resource manager, but it should be ignored.
 
-    Limitations: in Linux, attached jobs always appear to complete with a zero exit code regardless
+    Limitations:
+    - In Linux, attached jobs always appear to complete with a zero exit code regardless
     of the actual exit code.
+    - Instantiation of a local executor from both parent process and a `fork()`-ed process
+    is not guaranteed to work. In general, using `fork()` and multi-threading in Linux is unsafe,
+    as suggested by the `fork()` man page. While PSI/J attempts to minimize problems that can
+    arise when `fork()` is combined with threads (which are used by PSI/J), no guarantees can be
+    made and the chances of unexpected behavior are high. Please do not use PSI/J with `fork()`.
+    If you do, please be mindful that support for using PSI/J with `fork()` will be limited.
     """
 
     def __init__(self, url: Optional[str] = None,

--- a/src/psij/utils.py
+++ b/src/psij/utils.py
@@ -1,5 +1,7 @@
+import os
+import threading
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Type, Dict
 import sys
 
 
@@ -19,3 +21,32 @@ def path_object_to_full_path(obj: Optional[object]) -> Optional[str]:
             sys.exit("This type " + type(obj).__name__
                      + " for a path is not supported, use pathlib instead")
     return p
+
+
+class SingletonThread(threading.Thread):
+    """
+    A convenience class to return a thread that is guaranteed to be unique to this process.
+
+    This is intended to work with fork() to ensure that each os.getpid() value is associated with
+    at most one thread. This is not safe. The safe thing, as pointed out by the fork() man page,
+    is to not use fork() with threads. However, this is here in an attempt to make it slightly
+    safer for when users really really want to take the risk against all advice.
+    """
+
+    _instances: Dict[int, 'SingletonThread'] = {}
+    _lock = threading.RLock()
+
+    @classmethod
+    def get_instance(cls: Type['SingletonThread']) -> 'SingletonThread':
+        """Returns a started instance of this thread.
+
+        The instance is guaranteed to be unique for this process. This method also guarantees
+        that a forked process will get a separate instance of this thread from the parent.
+        """
+        with cls._lock:
+            my_pid = os.getpid()
+            if my_pid not in cls._instances:
+                instance = cls()
+                cls._instances[my_pid] = instance
+                instance.start()
+            return cls._instances[my_pid]

--- a/tests/test_issue_387_1.py
+++ b/tests/test_issue_387_1.py
@@ -1,0 +1,11 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.timeout(5)
+def test_issue_387_1() -> None:
+    subprocess.run([sys.executable, os.path.abspath(__file__)[:-2] + '.run'],
+                   shell=True, check=True, capture_output=True)

--- a/tests/test_issue_387_1.run
+++ b/tests/test_issue_387_1.run
@@ -1,3 +1,6 @@
+# This test must be run in a separate process, since it is sensitive
+# to threading and process context.
+
 import logging
 import os
 from multiprocessing import Process, set_start_method

--- a/tests/test_issue_387_1.run
+++ b/tests/test_issue_387_1.run
@@ -1,0 +1,40 @@
+import logging
+import os
+from multiprocessing import Process, set_start_method
+from threading import Thread
+
+import psij
+
+
+def func():
+    # Get logs from PSI/J
+    logger = logging.getLogger()
+    logger.setLevel("DEBUG")
+    logger.addHandler(logging.StreamHandler())
+
+    exe = psij.JobExecutor.get_instance("local")
+    job = psij.Job(psij.JobSpec("test", "echo", arguments=["foo"]))
+    exe.submit(job)
+    print(job, flush=True)
+
+    # This hangs on the second round
+    job.wait()
+    print(job, flush=True)
+
+
+def fn():
+    print(os.getpid())
+
+
+if __name__ == "__main__":
+    Thread(target=fn).start()
+    set_start_method("fork")
+    p = Process(target=func)
+    p.start()
+    p.join()
+
+    print("Done, and again...")
+
+    p = Process(target=func)
+    p.start()
+    p.join()

--- a/tests/test_issue_387_2.py
+++ b/tests/test_issue_387_2.py
@@ -1,0 +1,11 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.timeout(5)
+def test_issue_387_2() -> None:
+    subprocess.run([sys.executable, os.path.abspath(__file__)[:-2] + '.run'],
+                   shell=True, check=True, capture_output=True)

--- a/tests/test_issue_387_2.run
+++ b/tests/test_issue_387_2.run
@@ -1,3 +1,6 @@
+# This test must be run in a separate process, since it is sensitive
+# to threading and process context.
+
 import logging
 from threading import Thread
 import psij

--- a/tests/test_issue_387_2.run
+++ b/tests/test_issue_387_2.run
@@ -1,0 +1,23 @@
+import logging
+from threading import Thread
+import psij
+
+
+def func():
+    # Get logs from PSI/J
+    logger = logging.getLogger()
+    logger.setLevel("DEBUG")
+    logger.addHandler(logging.StreamHandler())
+
+    exe = psij.JobExecutor.get_instance("local")
+    job = psij.Job(psij.JobSpec("test", "echo", arguments=["foo"]))
+    exe.submit(job)
+
+    # This hangs
+    job.wait()
+
+if __name__ == "__main__":
+    p = Thread(target=func)
+    p.start()
+    p.join()
+

--- a/tests/test_issue_387_3.py
+++ b/tests/test_issue_387_3.py
@@ -1,0 +1,11 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.timeout(5)
+def test_issue_387_3() -> None:
+    subprocess.run([sys.executable, os.path.abspath(__file__)[:-2] + '.run'],
+                   shell=True, check=True, capture_output=True)

--- a/tests/test_issue_387_3.run
+++ b/tests/test_issue_387_3.run
@@ -1,3 +1,6 @@
+# This test must be run in a separate process, since it is sensitive
+# to threading and process context.
+
 import logging
 from threading import Thread
 import psij

--- a/tests/test_issue_387_3.run
+++ b/tests/test_issue_387_3.run
@@ -1,0 +1,23 @@
+import logging
+from threading import Thread
+import psij
+
+
+def func():
+    # Get logs from PSI/J
+    logger = logging.getLogger()
+    logger.setLevel("DEBUG")
+    logger.addHandler(logging.StreamHandler())
+
+    exe = psij.JobExecutor.get_instance("local")
+    job = psij.Job(psij.JobSpec("test", "echo", arguments=["foo"]))
+    exe.submit(job)
+
+    # This hangs
+    job.wait()
+
+if __name__ == "__main__":
+    p = Thread(target=func)
+    p.start()
+    p.join()
+


### PR DESCRIPTION
This PR attempts to more gracefully deal with situations such as those in issue #387.

It does so by considering singleton threads to be associated with the current PID rather than a flag in memory, since values are
copied by `fork()`.

This is not really a solution for #387. The solution is, as advised by the `fork()` man page, to not use `fork()` with threads. It does not work and it is not meant to work.

The PR also moves the signal attachment back to the global scope of the local executor. The issue, as pointed out in #387, is that signal handlers in Python can only be attached from the main thread. Unfortunately, there is no way to guarantee, in Python, that a particular piece of code will only be called from the main thread. However, we can somewhat constrain the problem by requiring that psij is only imported from the main thread.