### PR TITLE
Added a simple check in `JobExecutor.submit()` to test if a job's

### DIFF
--- a/src/psij/job_executor.py
+++ b/src/psij/job_executor.py
@@ -105,6 +105,8 @@ class JobExecutor(ABC):
                         raise TypeError('environment key "%s" has non-string value (%s)'
                                         % (k, type(v).__name__))
 
+        if job.executor is not None:
+            raise InvalidJobException('Job is already associated with an executor')
         job.executor = self
         return spec
 


### PR DESCRIPTION
executor property is already set (which would indicate that it was submitted before).