### PR TITLE
Allow for `str` paths as inputs to `JobSpec`

### DIFF
--- a/src/psij/job_spec.py
+++ b/src/psij/job_spec.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import sys
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional
 
 from typeguard import check_argument_types
 
 from psij.job_attributes import JobAttributes
 from psij.resource_spec import ResourceSpec
-
 from psij.utils import path_object_to_full_path as o2p
 
 
@@ -14,12 +15,12 @@ class JobSpec(object):
     """A class to hold information about the characteristics of a:class:`~psij.Job`."""
 
     def __init__(self, name: Optional[str] = None, executable: Optional[str] = None,
-                 arguments: Optional[List[str]] = None, directory: Optional[Path] = None,
+                 arguments: Optional[List[str]] = None, directory: Optional[str | Path] = None,
                  inherit_environment: bool = True, environment: Optional[Dict[str, str]] = None,
-                 stdin_path: Optional[Path] = None, stdout_path: Optional[Path] = None,
-                 stderr_path: Optional[Path] = None, resources: Optional[ResourceSpec] = None,
-                 attributes: Optional[JobAttributes] = None, pre_launch: Optional[Path] = None,
-                 post_launch: Optional[Path] = None, launcher: Optional[str] = None):
+                 stdin_path: Optional[str | Path] = None, stdout_path: Optional[str | Path] = None,
+                 stderr_path: Optional[str | Path] = None, resources: Optional[ResourceSpec] = None,
+                 attributes: Optional[JobAttributes] = None, pre_launch: Optional[str | Path] = None,
+                 post_launch: Optional[str | Path] = None, launcher: Optional[str] = None):
         """
         Constructs a `JobSpec` object while allowing its properties to be initialized.
 

--- a/tests/test_job_spec.py
+++ b/tests/test_job_spec.py
@@ -1,7 +1,9 @@
+import os
+from pathlib import Path
 
 import pytest
 
-from psij import JobSpec, JobExecutor, Job
+from psij import Job, JobExecutor, JobSpec
 
 
 def _test_spec(spec: JobSpec) -> None:
@@ -32,8 +34,12 @@ def test_environment_types() -> None:
     spec.environment = {'foo': 'bar'}
     assert spec.environment['foo'] == 'bar'
 
-    spec.environment = {'foo': 'biz'}
-    assert spec.environment['foo'] == 'biz'
+    assert JobSpec(directory=os.path.join("test", "path")).directory == Path("test") / "path"
+    assert JobSpec(stdin_path=os.path.join("test", "path")).directory == Path("test") / "path"
+    assert JobSpec(stdout_path=os.path.join("test", "path")).directory == Path("test") / "path"
+    assert JobSpec(stderr_path=os.path.join("test", "path")).directory == Path("test") / "path"
+    assert JobSpec(pre_launch=os.path.join("test", "path")).directory == Path("test") / "path"
+    assert JobSpec(post_launch=os.path.join("test", "path")).directory == Path("test") / "path"
 
 
 test_environment_types()

--- a/tests/test_job_spec.py
+++ b/tests/test_job_spec.py
@@ -34,6 +34,9 @@ def test_environment_types() -> None:
     spec.environment = {'foo': 'bar'}
     assert spec.environment['foo'] == 'bar'
 
+    spec.environment = {'foo': 'biz'}
+    assert spec.environment['foo'] == 'biz'
+
     assert JobSpec(directory=os.path.join("test", "path")).directory == Path("test") / "path"
     assert JobSpec(stdin_path=os.path.join("test", "path")).directory == Path("test") / "path"
     assert JobSpec(stdout_path=os.path.join("test", "path")).directory == Path("test") / "path"


### PR DESCRIPTION
Currently, the various path kwargs in `JobSpec`, such as `directory` and `stdout_path`, require the user to input them as `Path` objects. It would arguably be more convenient to allow the user to pass in any `PathLike` object, particularly a `str` representation. This PR simply calls `Path()` on these kwargs to automatically convert them to `Path` objects if they aren't already.