### PR TITLE
Properly implement wait according to spec (i.e., wait for all states

### DIFF
--- a/src/psij/__init__.py
+++ b/src/psij/__init__.py
@@ -7,7 +7,7 @@ import sys
 from typing import Callable, TypeVar
 
 from psij.descriptor import Descriptor
-from .exceptions import SubmitException, InvalidJobException, UnreachableStateException
+from .exceptions import SubmitException, InvalidJobException
 from .job import Job, JobStatusCallback
 from .job_attributes import JobAttributes
 from .job_executor import JobExecutor

--- a/src/psij/exceptions.py
+++ b/src/psij/exceptions.py
@@ -66,26 +66,3 @@ class SubmitException(Exception):
         conditions such an error would persist across subsequent re-tries until correct credentials
         are used.
         """
-
-
-class UnreachableStateException(Exception):
-    """
-    Indicates that a job state being waited for cannot be reached.
-
-    This exception is thrown when the :func:`~psij.Job.wait` method is called with a set of
-    states that cannot be reached by the job when the call is made.
-    """
-
-    def __init__(self, status: 'psij.JobStatus') -> None:
-        """
-        Constructs an `UnreachableStateException`.
-
-        :param status: The :class:`~psij.JobStatus` that the job was in when
-            :func:`~psij.Job.wait` was called and which prevents the desired states to be
-            reached.
-        """
-        self.status = status
-        """
-        Returns the job status that has caused an implementation to determine that the desired
-        states passed to the :func:`~psij.Job.wait` method cannot be reached.
-        """

--- a/src/psij/job_state.py
+++ b/src/psij/job_state.py
@@ -108,6 +108,10 @@ class JobState(bytes, Enum):
         """All states are consider true-ish."""
         return True
 
+    def __hash__(self) -> int:
+        """Returns a hash for this object."""
+        return self._value_  # type: ignore
+
 
 class JobStateOrder:
     """A class that can be used to reconstruct missing states."""

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,0 +1,31 @@
+from datetime import timedelta
+
+from psij import Job, JobExecutor, JobSpec, JobState
+
+
+def _test_wait() -> None:
+    ex = JobExecutor.get_instance('local')
+    job = Job(JobSpec('/bin/sleep', ['4']))
+    ex.submit(job)
+    status = job.wait(target_states=JobState.ACTIVE)
+    assert status is not None
+    assert status.state == JobState.ACTIVE
+
+    status = job.wait(target_states=JobState.QUEUED)
+    assert status is not None
+    assert status.state == JobState.ACTIVE
+
+    status = job.wait(timedelta(milliseconds=100))
+    assert status is None
+
+    status = job.wait()
+    assert status is not None
+    assert status.state == JobState.COMPLETED
+
+    status = job.wait(target_states=JobState.QUEUED)
+    assert status is not None
+    assert status.state == JobState.COMPLETED
+
+    status = job.wait(target_states=JobState.FAILED)
+    assert status is not None
+    assert status.state == JobState.COMPLETED


### PR DESCRIPTION
greater than `target_states` not just for `target_states`).

This goes a bit further by also implementing the yet-to-be-merged updates from https://github.com/ExaWorks/job-api-spec/pull/178