### PR TITLE
Test submit script generation basics

### DIFF
--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from datetime import timedelta
 from pathlib import Path
 from threading import Thread, RLock
-from typing import Optional, List, Dict, Collection, cast, TextIO, Union
+from typing import Optional, List, Dict, Collection, cast, Union, IO
 
 from .escape_functions import bash_escape
 from psij.launchers.script_based_launcher import ScriptBasedLauncher
@@ -268,7 +268,7 @@ class BatchSchedulerExecutor(JobExecutor):
 
     @abstractmethod
     def generate_submit_script(self, job: Job, context: Dict[str, object],
-                               submit_file: TextIO) -> None:
+                               submit_file: IO[str]) -> None:
         """Called to generate a submit script for a job.
 
         Concrete implementations of batch scheduler executors must override this method in

--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -38,6 +38,8 @@ def _attrs_to_mustache(job: Job) -> Dict[str, Union[object, List[Dict[str, objec
     for k, v in job.spec.attributes._custom_attributes.items():
         ks = k.split('.', maxsplit=1)
         if len(ks) == 2:
+            # always use lower case here
+            ks[0] = ks[0].lower()
             if ks[0] not in r:
                 r[ks[0]] = []
             cast(List[Dict[str, object]], r[ks[0]]).append({'key': ks[1], 'value': v})

--- a/src/psij/executors/batch/cobalt.py
+++ b/src/psij/executors/batch/cobalt.py
@@ -1,7 +1,7 @@
 """Defines a JobExecutor for the Cobalt resource manager."""
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional, Collection, List, Dict, TextIO
+from typing import Optional, Collection, List, Dict, IO
 import re
 import os
 import stat
@@ -59,7 +59,7 @@ class CobaltJobExecutor(BatchSchedulerExecutor):
         )
 
     def generate_submit_script(
-        self, job: Job, context: Dict[str, object], submit_file: TextIO
+        self, job: Job, context: Dict[str, object], submit_file: IO[str]
     ) -> None:
         """See :meth:`~.BatchSchedulerExecutor.generate_submit_script`."""
         self.generator.generate_submit_script(job, context, submit_file)

--- a/src/psij/executors/batch/cobalt/cobalt.mustache
+++ b/src/psij/executors/batch/cobalt/cobalt.mustache
@@ -20,13 +20,22 @@
     {{#queue_name}}
 #COBALT --queue={{.}}
     {{/queue_name}}
+    {{!Like PBS, Cobalt uses specially named queues for reservations, so we send the job to the
+    respective queue when a reservation ID is specified.}}
+    {{#reservation_id}}
+#COBALT --queue={{.}}
+    {{/reservation_id}}
     {{#project_name}}
 #COBALT --project={{.}}
     {{/project_name}}
-    {{#custom_attributes.COBALT}}
-#COBALT --{{key}}="{{value}}"
-    {{/custom_attributes.COBALT}}
 {{/job.spec.attributes}}
+
+{{#custom_attributes}}
+    {{#cobalt}}
+#COBALT --{{key}}="{{value}}"
+    {{/cobalt}}
+{{/custom_attributes}}
+
 
 {{#env}}
 #COBALT --env {{name}}={{value}}

--- a/src/psij/executors/batch/lsf.py
+++ b/src/psij/executors/batch/lsf.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from pathlib import Path
 import re
 import json
-from typing import Optional, Collection, List, Dict, TextIO
+from typing import Optional, Collection, List, Dict, IO
 
 from psij import Job, JobStatus, JobState, SubmitException
 from psij.executors.batch.batch_scheduler_executor import (
@@ -62,7 +62,7 @@ class LsfJobExecutor(BatchSchedulerExecutor):
         )
 
     def generate_submit_script(
-        self, job: Job, context: Dict[str, object], submit_file: TextIO
+        self, job: Job, context: Dict[str, object], submit_file: IO[str]
     ) -> None:
         """See :meth:`~.BatchSchedulerExecutor.generate_submit_script`."""
         assert job.spec is not None

--- a/src/psij/executors/batch/lsf/lsf.mustache
+++ b/src/psij/executors/batch/lsf/lsf.mustache
@@ -59,6 +59,13 @@
 
 {{/job.spec.attributes}}
 
+{{#custom_attributes}}
+    {{#lsf}}
+#BSUB -{{key}} "{{value}}"
+    {{/lsf}}
+{{/custom_attributes}}
+
+
 {{!since we redirect the output manually, below, tell LSF not to do its own thing, since it
 only results in empty files that are not cleaned up}}
 #BSUB -e /dev/null

--- a/src/psij/executors/batch/pbspro.py
+++ b/src/psij/executors/batch/pbspro.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional, Collection, List, Dict, TextIO
+from typing import Optional, Collection, List, Dict, IO
 
 from psij import Job, JobStatus, JobState, SubmitException
 from psij.executors.batch.batch_scheduler_executor import BatchSchedulerExecutor, \
@@ -72,7 +72,7 @@ class PBSProJobExecutor(BatchSchedulerExecutor):
     # Submit methods
 
     def generate_submit_script(self, job: Job, context: Dict[str, object],
-                               submit_file: TextIO) -> None:
+                               submit_file: IO[str]) -> None:
         """See :meth:`~.BatchSchedulerExecutor.generate_submit_script`."""
         self.generator.generate_submit_script(job, context, submit_file)
 

--- a/src/psij/executors/batch/pbspro/pbspro.mustache
+++ b/src/psij/executors/batch/pbspro/pbspro.mustache
@@ -16,17 +16,25 @@
 {{/formatted_job_duration}}
 
 {{#job.spec.attributes}}
-    {{#projectName}}
+    {{#project_name}}
 #PBS -P {{.}}
-    {{/projectName}}
-    {{#queueName}}
+    {{/project_name}}
+    {{#queue_name}}
 #PBS -q {{.}}
-    {{/queueName}}
-    {{#custom_attributes.pbs}}
-#PBS -{{key}} "{{value}}"
-    {{/custom_attributes.pbs}}
-
+    {{/queue_name}}
+    {{!PBS uses specially named queues for reservations, so we send the job to the respective
+    queue when a reservation ID is specified.}}
+    {{#reservation_id}}
+#PBS -q {{.}}
+    {{/reservation_id}}
 {{/job.spec.attributes}}
+
+{{#custom_attributes}}
+    {{#pbs}}
+#PBS -{{key}} "{{value}}"
+    {{/pbs}}
+{{/custom_attributes}}
+
 
 {{!since we redirect the output manually, below, tell pbs not to do its own thing, since it
 only results in empty files that are not cleaned up}}

--- a/src/psij/executors/batch/script_generator.py
+++ b/src/psij/executors/batch/script_generator.py
@@ -1,6 +1,6 @@
 import pathlib
 from abc import ABC
-from typing import TextIO, Dict, Callable
+from typing import Dict, Callable, IO
 
 import pystache
 
@@ -29,7 +29,7 @@ class SubmitScriptGenerator(ABC):
         """
         self.config = config
 
-    def generate_submit_script(self, job: Job, context: Dict[str, object], out: TextIO) -> None:
+    def generate_submit_script(self, job: Job, context: Dict[str, object], out: IO[str]) -> None:
         """Generates a job submit script.
 
         Concerete implementations of submit script generators must implement this method. Its
@@ -76,7 +76,7 @@ class TemplatedScriptGenerator(SubmitScriptGenerator):
             self.template = pystache.parse(template_file.read())
         self.renderer = pystache.Renderer(escape=escape)
 
-    def generate_submit_script(self, job: Job, context: Dict[str, object], out: TextIO) -> None:
+    def generate_submit_script(self, job: Job, context: Dict[str, object], out: IO[str]) -> None:
         """See :func:`~SubmitScriptGenerator.generate_submit_script`.
 
         Renders a submit script using the template specified when this generator was constructed.

--- a/src/psij/executors/batch/slurm.py
+++ b/src/psij/executors/batch/slurm.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional, Collection, List, Dict, TextIO
+from typing import Optional, Collection, List, Dict, IO
 
 from psij import Job, JobStatus, JobState, SubmitException
 from psij.executors.batch.batch_scheduler_executor import BatchSchedulerExecutor, \
@@ -117,7 +117,7 @@ class SlurmJobExecutor(BatchSchedulerExecutor):
                                                   / 'slurm.mustache')
 
     def generate_submit_script(self, job: Job, context: Dict[str, object],
-                               submit_file: TextIO) -> None:
+                               submit_file: IO[str]) -> None:
         """See :meth:`~.BatchSchedulerExecutor.generate_submit_script`."""
         self.generator.generate_submit_script(job, context, submit_file)
 

--- a/src/psij/executors/batch/slurm/slurm.mustache
+++ b/src/psij/executors/batch/slurm/slurm.mustache
@@ -61,12 +61,13 @@
     {{#reservation_id}}
 #SBATCH --reservation="{{.}}"
     {{/reservation_id}}
-
-    {{#custom_attributes.slurm}}
-#SBATCH --{{key}}="{{value}}"
-    {{/custom_attributes.slurm}}
-
 {{/job.spec.attributes}}
+
+{{#custom_attributes}}
+    {{#slurm}}
+#SBATCH --{{key}}="{{value}}"
+    {{/slurm}}
+{{/custom_attributes}}
 
 {{!since we redirect the output manually, below, tell slurm not to do its own thing, since it
 only results in empty files that are not cleaned up}}

--- a/tests/plugins1/_batch_test/_batch_test.py
+++ b/tests/plugins1/_batch_test/_batch_test.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import Optional, Collection, List, Dict, TextIO, cast
+from typing import Optional, Collection, List, Dict, IO, cast
 
 from psij import Job, JobStatus, JobState, SubmitException, JobExecutorConfig, ResourceSpecV1
 from psij.executors.batch.batch_scheduler_executor import BatchSchedulerExecutor, \
@@ -48,7 +48,7 @@ class _TestJobExecutor(BatchSchedulerExecutor):
                                                   / 'test.mustache')
 
     def generate_submit_script(self, job: Job, context: Dict[str, object],
-                               submit_file: TextIO) -> None:
+                               submit_file: IO[str]) -> None:
         self.generator.generate_submit_script(job, context, submit_file)
 
     def get_submit_command(self, job: Job, submit_file_path: Path) -> List[str]:

--- a/tests/plugins1/_batch_test/test/test.mustache
+++ b/tests/plugins1/_batch_test/test/test.mustache
@@ -13,14 +13,23 @@ export PSIJ_TEST_BATCH_EXEC_COUNT={{.}}
 {{/job.spec.resources}}
 
 {{#job.spec.attributes}}
+    {{#queue_name}}
+export PSIJ_TEST_BATCH_EXEC_QUEUE="{{.}}"
+    {{/queue_name}}
     {{#project_name}}
 export PSIJ_TEST_BATCH_EXEC_PROJECT="{{.}}"
     {{/project_name}}
-
-    {{#custom_attributes.test}}
-export {{key}}="{{value}}"
-    {{/custom_attributes.test}}
+    {{#reservation_id}}
+export PSIJ_TEST_BATCH_EXEC_RES_ID="{{.}}"
+    {{/reservation_id}}
 {{/job.spec.attributes}}
+
+{{#custom_attributes}}
+    {{#batch-test}}
+export {{key}}="{{value}}"
+    {{/batch-test}}
+{{/custom_attributes}}
+
 
 {{#job.spec.inherit_environment}}env \{{/job.spec.inherit_environment}}{{^job.spec.inherit_environment}}env --ignore-environment \{{/job.spec.inherit_environment}}{{#env}}
 {{name}}="{{value}}" \

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -195,6 +195,8 @@ def _check_str_attrs(ex: BatchSchedulerExecutor, job: Job, names: List[str],
 
 
 _PREFIX_TR = {'pbspro': 'pbs'}
+
+
 def _get_attr_prefix(exec_name: str) -> str:
     if exec_name in _PREFIX_TR:
         return _PREFIX_TR[exec_name]

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,11 +1,16 @@
+import secrets
 import uuid
 from pathlib import Path
+from typing import List, Callable, Dict
 
-from psij import SubmitException, Job, JobSpec, JobState
-from tempfile import TemporaryDirectory
+import pytest
+
+from psij import SubmitException, Job, JobSpec, JobState, JobExecutor, JobAttributes, ResourceSpecV1
+from tempfile import TemporaryDirectory, TemporaryFile
 
 from executor_test_params import ExecutorTestParams
 from _test_tools import _get_executor_instance, _get_timeout, assert_completed, _make_test_dir
+from psij.executors.batch.batch_scheduler_executor import BatchSchedulerExecutor
 
 
 def test_simple_job(execparams: ExecutorTestParams) -> None:
@@ -161,3 +166,58 @@ def test_list(execparams: ExecutorTestParams) -> None:
     assert job.native_id is not None
     ids = ex.list()
     assert job.native_id in ids
+
+
+def _get_batch_executors() -> List[str]:
+    r = []
+    for name in JobExecutor.get_executor_names():
+        try:
+            ex = JobExecutor.get_instance(name)
+            if isinstance(ex, BatchSchedulerExecutor):
+                r.append(name)
+        except Exception:
+            pass
+    return r
+
+
+def _check_str_attrs(ex: BatchSchedulerExecutor, job: Job, names: List[str],
+                     l: Callable[[str, str], None]) -> None:
+    for name in names:
+        tok = secrets.token_hex()
+        l(name, tok)
+        with TemporaryFile(mode='w+') as f:
+            ex.generate_submit_script(job, ex._create_script_context(job), f)
+            f.seek(0)
+            contents = f.read()
+            if contents.find(tok) == -1:
+                print('Failed to find "%s" in:\n%s' % (tok, contents))
+                pytest.fail('Script generation failed for %s' % name)
+
+
+_PREFIX_TR = {'pbspro': 'pbs'}
+def _get_attr_prefix(exec_name: str) -> str:
+    if exec_name in _PREFIX_TR:
+        return _PREFIX_TR[exec_name]
+    else:
+        return exec_name
+
+
+@pytest.mark.parametrize('exec_name', _get_batch_executors())
+def test_submit_script_generation(exec_name: str) -> None:
+    ex = JobExecutor.get_instance(exec_name)
+    assert isinstance(ex, BatchSchedulerExecutor)
+
+    c_attrs: Dict[str, object] = {}
+    attrs = JobAttributes(custom_attributes=c_attrs)
+    res = ResourceSpecV1()
+    spec = JobSpec(resources=res, attributes=attrs)
+    spec.launcher = 'single'
+    job = Job(spec=spec)
+
+    prefix = _get_attr_prefix(exec_name)
+    _check_str_attrs(ex, job, ['executable', 'directory'],
+                     lambda k, v: setattr(spec, k, v))
+    _check_str_attrs(ex, job, ['queue_name', 'project_name', 'reservation_id'],
+                     lambda k, v: setattr(attrs, k, v))
+    _check_str_attrs(ex, job, [prefix + '.cust_attr1', prefix + '.cust_attr2'],
+                     lambda k, v: c_attrs.__setitem__(k, v))


### PR DESCRIPTION
This adds a test that sets various string properties of the job spec tree to some random value and then checks the generated submit script for that value.

It also fixes #416. It is unclear what causes #416 to happen, since there are no code changes in psij that are related. The one possible explanation is that pystache became more strict on processing keys and will not make a global lookup if the current dictionary is missing a key.

As a result of this test, a few more attributes that were missing in various executors are now added. It is somewhat unclear what the benefits of some of these additions are (PBS uses special queue names for reservations rather than requiring some reservation id attribute on the job, like Slurm or LSF, so arguably one does not need to handle the reservation_id attribute for PBS, but then it's probably better to do so for portability reasons.)