### PR TITLE
There is no need to escape values here since the script generator alr…

### DIFF
--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from threading import Thread, RLock
 from typing import Optional, List, Dict, Collection, cast, Union, IO
 
-from .escape_functions import bash_escape
 from psij.launchers.script_based_launcher import ScriptBasedLauncher
 
 from psij import JobExecutor, JobExecutorConfig, Launcher, Job, SubmitException, \

--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -55,7 +55,7 @@ def _env_to_mustache(job: Job) -> List[Dict[str, str]]:
 
     r = []
     for k, v in job.spec.environment.items():
-        r.append({'name': k, 'value': bash_escape(v)})
+        r.append({'name': k, 'value': v})
     return r
 
 


### PR DESCRIPTION
…eady does it.

Fixes #423 