### PR TITLE
Some testing fixes

### DIFF
--- a/docs/_static/extras.js
+++ b/docs/_static/extras.js
@@ -67,7 +67,6 @@ function detectAll(selectorType) {
     // simple_value_2. However, if either "B" or "C" are selected in either selector,
     // we want to change both.
 
-    console.log("type:" + selectorType);
     $("p." + selectorType + "-selector").addClass(selectorType + "-item");
     var prevSpans = [];
     $("span").each(function() {
@@ -90,6 +89,28 @@ function detectAll(selectorType) {
             else if (text == "project_name") {
                 $(this).text("PROJECT_NAME");
             }
+        }
+        if (text == '_get_executor_instance') {
+            // replace _get_executor_instance(execparams, job) with selector value
+            // the spans are: "_get_executor_instance", "(", "execparams",   ",", "job",    ")"
+            // we need:       "JobExecutor",            ".", "get_instance", "(", selector, ")"
+            // the classes happen to match, so just replace the text
+            // also, remove the space after the comma, which is rendered by sphinx as a text
+            // node rather than span like everything else
+            var crt = $(this);
+            var space = $(this).next().next().next().get(0).nextSibling;
+            if (space.nodeType == 3) {
+                space.nodeValue = "";
+            }
+            else {
+                console.log("Expected a text node: ", space);
+            }
+            var newText = ["JobExecutor", ".", "get_instance", "("];
+            for (var i = 0; i < 4; i++) {
+                crt.text(newText[i]);
+                crt = crt.next();
+            }
+            crt.addClass(selectorType + "-item").addClass("psij-selector-value");
         }
         prevSpans.push($(this));
         if (prevSpans.length > 2) {

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -254,7 +254,7 @@ processes on each node, for a total of 8 processes:
 .. literalinclude:: ../tests/user_guide/test_resourcespec.py
     :language: python
     :dedent: 4
-    :lines: 9-17
+    :lines: 8-16
 
 .. note::
     All processes of a job will share at most one MPI communicator
@@ -332,7 +332,7 @@ and an instance of the
 .. literalinclude:: ../tests/user_guide/test_scheduling_information.py
     :language: python
     :dedent: 4
-    :lines: 11-19
+    :lines: 10-18,21-22
 
 where `QUEUE_NAME` is the LRM queue where the job should be sent and
 `PROJECT_NAME` is a project/account that may need to be specified for

--- a/tests/getting_started/test_simple_example.py
+++ b/tests/getting_started/test_simple_example.py
@@ -1,13 +1,13 @@
 from executor_test_params import ExecutorTestParams
 
-from _test_tools import assert_completed
+from _test_tools import assert_completed, _get_executor_instance
 
 
 def test_getting_started_single_job(execparams: ExecutorTestParams) -> None:
-    from psij import Job, JobSpec, JobExecutor
+    from psij import Job, JobSpec
 
-    ex = JobExecutor.get_instance(execparams.executor)
     job = Job(JobSpec(executable="/bin/date"))
+    ex = _get_executor_instance(execparams, job)
     ex.submit(job)
 
     status = job.wait()

--- a/tests/test_nodefile.py
+++ b/tests/test_nodefile.py
@@ -4,9 +4,9 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from _test_tools import assert_completed
+from _test_tools import assert_completed, _get_executor_instance
 from executor_test_params import ExecutorTestParams
-from psij import Job, JobSpec, JobExecutor, ResourceSpecV1
+from psij import Job, JobSpec, ResourceSpecV1
 
 NOT_TESTED = set(['rp', 'flux'])
 
@@ -24,7 +24,7 @@ def test_nodefile(execparams: ExecutorTestParams) -> None:
                        stdout_path=outp)
         job = Job(spec)
         spec.resources = ResourceSpecV1(process_count=N_PROC)
-        ex = JobExecutor.get_instance(execparams.executor)
+        ex = _get_executor_instance(execparams, job)
         ex.submit(job)
         status = job.wait()
         assert_completed(job, status)

--- a/tests/user_guide/test_resourcespec.py
+++ b/tests/user_guide/test_resourcespec.py
@@ -1,11 +1,10 @@
-from psij import Job, JobSpec, JobExecutor, ResourceSpecV1
+from psij import Job, JobSpec, ResourceSpecV1
 from executor_test_params import ExecutorTestParams
 
-from _test_tools import assert_completed
+from _test_tools import assert_completed, _get_executor_instance
 
 
 def test_user_guide_resourcespec(execparams: ExecutorTestParams) -> None:
-    ex = JobExecutor.get_instance(execparams.executor)
     job = Job(
         JobSpec(
             executable='/bin/date',
@@ -15,6 +14,7 @@ def test_user_guide_resourcespec(execparams: ExecutorTestParams) -> None:
             )
         )
     )
+    ex = _get_executor_instance(execparams, job)
     ex.submit(job)
     status = job.wait()
     assert_completed(job, status)

--- a/tests/user_guide/test_scheduling_information.py
+++ b/tests/user_guide/test_scheduling_information.py
@@ -1,12 +1,11 @@
-from psij import Job, JobSpec, JobExecutor, JobAttributes
+from psij import Job, JobSpec, JobAttributes
 # from psij import JobAttributes
 from executor_test_params import ExecutorTestParams
 
-from _test_tools import assert_completed
+from _test_tools import assert_completed, _get_executor_instance
 
 
 def test_user_guide_scheduling_info(execparams: ExecutorTestParams) -> None:
-    executor = JobExecutor.get_instance(execparams.executor)
 
     job = Job(
         JobSpec(
@@ -17,6 +16,8 @@ def test_user_guide_scheduling_info(execparams: ExecutorTestParams) -> None:
             )
         )
     )
+
+    executor = _get_executor_instance(execparams, job)
 
     executor.submit(job)
     status = job.wait()


### PR DESCRIPTION
This basically makes sure that `_get_executor_instance` is used when potentially dealing with queuing systems. This is done in order
to propagate various job attributes from testing.conf.

It also updates the web rendering library to recognize when a doc example has `_get_executor_instance(...)` and replace with something more palatable. 