### PR TITLE
sphinxcontrib-applehelp 1.0.8 added a requirement for Sphinx 5.0, which

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,7 +11,7 @@ Sphinx==4.5.0
 sphinx_rtd_theme
 sphinx-tabs==3.2.0
 sphinx-multiversion
-sphinxcontrib-applehelp=1.0.7
+sphinxcontrib-applehelp==1.0.7
 
 # For the web version of the docs
 cloud_sptheme == 1.10.1.post20200504175005

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,6 +11,7 @@ Sphinx==4.5.0
 sphinx_rtd_theme
 sphinx-tabs==3.2.0
 sphinx-multiversion
+sphinxcontrib-applehelp=1.0.7
 
 # For the web version of the docs
 cloud_sptheme == 1.10.1.post20200504175005

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,7 +11,15 @@ Sphinx==4.5.0
 sphinx_rtd_theme
 sphinx-tabs==3.2.0
 sphinx-multiversion
+
+# These are not requirements for PSI/J, but we must pin the version
+# since Sphinx 4.5.0 does not properly do so and later versions of
+# these plugins require Sphinx >= 5.0.0
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.3
 
 # For the web version of the docs
 cloud_sptheme == 1.10.1.post20200504175005

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,7 +11,7 @@ Sphinx==4.5.0
 sphinx_rtd_theme
 sphinx-tabs==3.2.0
 sphinx-multiversion
-sphinxcontrib-applehelp==1.0.7
+sphinxcontrib-applehelp==1.0.4
 
 # For the web version of the docs
 cloud_sptheme == 1.10.1.post20200504175005


### PR DESCRIPTION
breaks Sphinx 4.5 who doesn't pin the dep to something compatible with it.

It's even more silly because we don't generate applehelp output.

