### PR TITLE
The process count, if not specified, would be empty. Most batch sched…

### DIFF
--- a/tests/plugins1/_batch_test/test/test.mustache
+++ b/tests/plugins1/_batch_test/test/test.mustache
@@ -6,6 +6,8 @@ exec &> "{{psij.script_dir}}/$PSIJ_BATCH_TEST_JOB_ID.out"
 cd "{{.}}"
 {{/job.spec.directory}}
 
+export PSIJ_TEST_BATCH_EXEC_COUNT=1
+
 {{#job.spec.resources}}
     {{#process_count}}
 export PSIJ_TEST_BATCH_EXEC_COUNT={{.}}


### PR DESCRIPTION
…ulers

interpret this using a default of 1. However, the batch test scheduler uses the empty env var as a parameter to `seq`, which may lead to failures.