### PR TITLE
Use `assert_completed` when possible and also change `assert_completed`

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -311,7 +311,7 @@ following example shows:
 .. literalinclude:: ../tests/user_guide/test_prelaunch.py
     :language: python
     :dedent: 4
-    :lines: 10-16
+    :lines: 12-18
 
 where the contents of ``pre_launch.sh`` is
 

--- a/tests/_test_tools.py
+++ b/tests/_test_tools.py
@@ -28,16 +28,19 @@ def _read_file(path: Optional[Path]) -> str:
         return f.read()
 
 
-def assert_completed(job: Job, status: Optional[JobStatus]) -> None:
+def assert_completed(job: Job, status: Optional[JobStatus], attached=False) -> None:
     assert status is not None
     if status.state != JobState.COMPLETED:
-        assert job.spec is not None
-        stdout = _read_file(job.spec.stdout_path)
-        stderr = _read_file(job.spec.stderr_path)
-        raise AssertionError('Job not completed. Exit code: %s, Status message: %s, '
-                             'stdout: %s, stderr: %s'
-                             % (status.exit_code, status.message, stdout, stderr))
-
+        if not attached:
+            assert job.spec is not None
+            stdout = _read_file(job.spec.stdout_path)
+            stderr = _read_file(job.spec.stderr_path)
+            raise AssertionError('Job not completed. Exit code: %s, Status message: %s, '
+                                 'stdout: %s, stderr: %s'
+                                 % (status.exit_code, status.message, stdout, stderr))
+        else:
+            raise AssertionError('Job not completed. Exit code: %s, Status message: %s'
+                                 % (status.exit_code, status.message))
 
 def _get_executor_instance(ep: ExecutorTestParams, job: Optional[Job] = None) -> JobExecutor:
     if job is not None:

--- a/tests/_test_tools.py
+++ b/tests/_test_tools.py
@@ -28,7 +28,7 @@ def _read_file(path: Optional[Path]) -> str:
         return f.read()
 
 
-def assert_completed(job: Job, status: Optional[JobStatus], attached=False) -> None:
+def assert_completed(job: Job, status: Optional[JobStatus], attached: bool = False) -> None:
     assert status is not None
     if status.state != JobState.COMPLETED:
         if not attached:
@@ -41,6 +41,7 @@ def assert_completed(job: Job, status: Optional[JobStatus], attached=False) -> N
         else:
             raise AssertionError('Job not completed. Exit code: %s, Status message: %s'
                                  % (status.exit_code, status.message))
+
 
 def _get_executor_instance(ep: ExecutorTestParams, job: Optional[Job] = None) -> JobExecutor:
     if job is not None:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -47,7 +47,7 @@ def test_attach(execparams: ExecutorTestParams) -> None:
     job2 = Job()
     ex.attach(job2, native_id)
     status2 = job2.wait(timeout=_get_timeout(execparams))
-    assert_completed(job2, status2)
+    assert_completed(job2, status2, attached=True)
     status1 = job1.wait(timeout=_get_timeout(execparams))
     assert_completed(job1, status1)
 
@@ -64,7 +64,7 @@ def test_attach2(execparams: ExecutorTestParams) -> None:
     ex2 = _get_executor_instance(execparams)
     ex2.attach(job2, native_id)
     status = job2.wait(timeout=_get_timeout(execparams))
-    assert_completed(job2, status)
+    assert_completed(job2, status, attached=True)
 
 
 def test_cancel(execparams: ExecutorTestParams) -> None:

--- a/tests/user_guide/test_prelaunch.py
+++ b/tests/user_guide/test_prelaunch.py
@@ -1,12 +1,14 @@
 import os
 from pathlib import Path
 
+from _test_tools import assert_completed
 from psij import Job, JobSpec, JobExecutor, JobState
 
 
 def test_user_guide_pre_launch() -> None:
     script_dir = os.path.dirname(os.path.realpath(__file__))
 
+    # START
     ex = JobExecutor.get_instance('local')
     spec = JobSpec('/bin/bash', ['-c', 'module is-loaded test'])
     spec.pre_launch = Path(script_dir) / 'pre_launch.sh'
@@ -14,5 +16,5 @@ def test_user_guide_pre_launch() -> None:
     job = Job(spec)
     ex.submit(job)
     status = job.wait()
-    assert status is not None
-    assert status.state == JobState.COMPLETED
+    # END
+    assert_completed(job, status)

--- a/tests/user_guide/test_prelaunch.py
+++ b/tests/user_guide/test_prelaunch.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 from _test_tools import assert_completed
-from psij import Job, JobSpec, JobExecutor, JobState
+from psij import Job, JobSpec, JobExecutor
 
 
 def test_user_guide_pre_launch() -> None:


### PR DESCRIPTION
to not complain of a null spec when checking an attached job.