### PR TITLE
Added a way to specify test filters for custom attributes.

### DIFF
--- a/testing.conf
+++ b/testing.conf
@@ -126,10 +126,15 @@ project_name =
 #
 # If a site needs specific job attributes to be specified, such as billing
 # accounts, they can be added here. The value is a comma separated list
-# of "executor.name": "value" pairs.
+# of "executor.attr_name": "value" pairs. A regular expression filter enclosed
+# in square brackets can be used after "custom_attributes" to specify that the
+# attributes should only apply to certain tests. The specified custom_attributes
+# directives are processed in the order in which they appear and a lack of a
+# filter is equivalent to a ".*" filter.
 #
 # custom_attributes = "slurm.account": "xyz", \
 #                     "slurm.constraint": "knl"
+# custom_attributes[test_nodefile\[slurm:.*\]] = "slurm.qos": "debug"
 
 custom_attributes =
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -443,7 +443,7 @@ def _now():
 def _process_custom_attributes(item):
     if not hasattr(item, 'callspec'):
         return
-    if not 'execparams' in item.callspec.params:
+    if 'execparams' not in item.callspec.params:
         return
     ep: Optional[List[Dict[str, Dict[str, object]]]] = item.callspec.params['execparams']
     if ep.custom_attributes_raw is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -443,6 +443,8 @@ def _now():
 def _process_custom_attributes(item):
     if not hasattr(item, 'callspec'):
         return
+    if not 'execparams' in item.callspec.params:
+        return
     ep: Optional[List[Dict[str, Dict[str, object]]]] = item.callspec.params['execparams']
     if ep.custom_attributes_raw is None:
         return

--- a/tests/executor_test_params.py
+++ b/tests/executor_test_params.py
@@ -7,7 +7,8 @@ class ExecutorTestParams:
 
     def __init__(self, spec: str, queue_name: Optional[str] = None,
                  project_name: Optional[str] = None,
-                 custom_attributes: Optional[Dict[str, object]] = None) -> None:
+                 custom_attributes_raw: Optional[Dict[str, Dict[str, object]]] = None) \
+            -> None:
         """
         Construct a new instance.
 
@@ -35,7 +36,8 @@ class ExecutorTestParams:
 
         self.queue_name = queue_name
         self.project_name = project_name
-        self.custom_attributes = custom_attributes
+        self.custom_attributes_raw = custom_attributes_raw
+        self.custom_attributes: Dict[str, object] = {}
 
     def __repr__(self) -> str:
         """Returns a string representation of this object."""


### PR DESCRIPTION
The motivation here is that, on Perlmutter, it's a wise idea to run most tests on shared nodes (since we don't want to burn too fast through a small allocation). However, some tests, such as tests that verify that multi-node jobs run on multiple nodes, will fail since the shared node mode (--qos=shared) does not allow for multi-node jobs. So there needs to be a way to use a different --qos parameter for certain tests.