### PR TITLE
Fix preload test on systems with the module tool installed

### DIFF
--- a/tests/user_guide/pre_launch.sh
+++ b/tests/user_guide/pre_launch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-module() {
+xmodule() {
     case "$1" in
         load)
             export MODULE_TEST_LOADED="1"
@@ -16,6 +16,6 @@ module() {
      esac
 }
 
-export -f module
+export -f xmodule
 
-module load test
+xmodule load test

--- a/tests/user_guide/test_prelaunch.py
+++ b/tests/user_guide/test_prelaunch.py
@@ -11,7 +11,7 @@ def test_user_guide_pre_launch() -> None:
     with _deploy(Path(script_dir) / 'pre_launch.sh') as pre_launch_sh_path:
         # START
         ex = JobExecutor.get_instance('local')
-        spec = JobSpec('/bin/bash', ['-c', 'module is-loaded test'])
+        spec = JobSpec('/bin/bash', ['-c', 'xmodule is-loaded test'])
         spec.pre_launch = pre_launch_sh_path
 
         job = Job(spec)


### PR DESCRIPTION
I haven't quite figured out how, but the actual module command, on systems in which it is present, has some uncanny ability of replacing the one you exported when a new instance of bash is launched. So, on systems on which module is actually available, this test fails. Renaming the function should fix it.