### PR TITLE
File staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ psi_j_python.egg-info/
 venv*
 .venv*
 build/
+.packages/

--- a/src/psij-descriptors/cobalt_descriptor.py
+++ b/src/psij-descriptors/cobalt_descriptor.py
@@ -3,5 +3,5 @@ from distutils.version import StrictVersion
 from psij.descriptor import Descriptor
 
 
-__PSI_J_EXECUTORS__ = [Descriptor(name="cobalt", nice_name='Cobalt', version=StrictVersion("0.0.1"),
+__PSI_J_EXECUTORS__ = [Descriptor(name="cobalt", nice_name='Cobalt', version=StrictVersion("0.2.0"),
                                   cls='psij.executors.batch.cobalt.CobaltJobExecutor')]

--- a/src/psij-descriptors/core_descriptors.py
+++ b/src/psij-descriptors/core_descriptors.py
@@ -2,15 +2,15 @@ from distutils.version import StrictVersion
 from psij.descriptor import Descriptor
 
 __PSI_J_EXECUTORS__ = [
-    Descriptor(name='local', nice_name='Local', version=StrictVersion('0.0.1'),
+    Descriptor(name='local', nice_name='Local', version=StrictVersion('0.2.0'),
                cls='psij.executors.local.LocalJobExecutor')
 ]
 
 __PSI_J_LAUNCHERS__ = [
-    Descriptor(name='single', version=StrictVersion('0.0.1'),
+    Descriptor(name='single', version=StrictVersion('0.2.0'),
                cls='psij.launchers.single.SingleLauncher'),
-    Descriptor(name='multiple', version=StrictVersion('0.0.1'),
+    Descriptor(name='multiple', version=StrictVersion('0.2.0'),
                cls='psij.launchers.multiple.MultipleLauncher'),
-    Descriptor(name='mpirun', version=StrictVersion('0.0.1'),
+    Descriptor(name='mpirun', version=StrictVersion('0.2.0'),
                cls='psij.launchers.mpirun.MPILauncher'),
 ]

--- a/src/psij-descriptors/lsf_descriptor.py
+++ b/src/psij-descriptors/lsf_descriptor.py
@@ -3,5 +3,5 @@ from distutils.version import StrictVersion
 from psij.descriptor import Descriptor
 
 
-__PSI_J_EXECUTORS__ = [Descriptor(name='lsf', nice_name='LSF', version=StrictVersion('0.0.1'),
+__PSI_J_EXECUTORS__ = [Descriptor(name='lsf', nice_name='LSF', version=StrictVersion('0.2.0'),
                                   cls='psij.executors.batch.lsf.LsfJobExecutor')]

--- a/src/psij-descriptors/pbs_descriptor.py
+++ b/src/psij-descriptors/pbs_descriptor.py
@@ -4,8 +4,8 @@ from psij.descriptor import Descriptor
 
 
 __PSI_J_EXECUTORS__ = [Descriptor(name='pbs', nice_name='PBS Pro', aliases=['pbspro'],
-                                  version=StrictVersion('0.0.2'),
+                                  version=StrictVersion('0.2.0'),
                                   cls='psij.executors.batch.pbs.PBSJobExecutor'),
                        Descriptor(name='pbs_classic', nice_name='PBS Classic', aliases=['torque'],
-                                  version=StrictVersion('0.0.2'),
+                                  version=StrictVersion('0.2.0'),
                                   cls='psij.executors.batch.pbs_classic.PBSClassicJobExecutor')]

--- a/src/psij-descriptors/slurm_descriptor.py
+++ b/src/psij-descriptors/slurm_descriptor.py
@@ -3,5 +3,5 @@ from distutils.version import StrictVersion
 from psij.descriptor import Descriptor
 
 
-__PSI_J_EXECUTORS__ = [Descriptor(name='slurm', nice_name='Slurm', version=StrictVersion('0.0.1'),
+__PSI_J_EXECUTORS__ = [Descriptor(name='slurm', nice_name='Slurm', version=StrictVersion('0.2.0'),
                                   cls='psij.executors.batch.slurm.SlurmJobExecutor')]

--- a/src/psij/exceptions.py
+++ b/src/psij/exceptions.py
@@ -62,3 +62,21 @@ class SubmitException(Exception):
         conditions such an error would persist across subsequent re-tries until correct credentials
         are used.
         """
+
+class CompositeException(Exception):
+    def __init__(self, ex: Exception) -> None:
+        self.exceptions = [ex]
+
+    def add_exception(self, ex: Exception) -> None:
+        self.exceptions.append(ex)
+
+
+class LauncherException(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__('Launcher failure: %s' % message)
+
+
+class JobException(Exception):
+    def __init__(self, exit_code: int) -> None:
+        super().__init__('Job exited with exit code %s' % exit_code)
+        self.exit_code = exit_code

--- a/src/psij/exceptions.py
+++ b/src/psij/exceptions.py
@@ -62,21 +62,3 @@ class SubmitException(Exception):
         conditions such an error would persist across subsequent re-tries until correct credentials
         are used.
         """
-
-class CompositeException(Exception):
-    def __init__(self, ex: Exception) -> None:
-        self.exceptions = [ex]
-
-    def add_exception(self, ex: Exception) -> None:
-        self.exceptions.append(ex)
-
-
-class LauncherException(Exception):
-    def __init__(self, message: str) -> None:
-        super().__init__('Launcher failure: %s' % message)
-
-
-class JobException(Exception):
-    def __init__(self, exit_code: int) -> None:
-        super().__init__('Job exited with exit code %s' % exit_code)
-        self.exit_code = exit_code

--- a/src/psij/executors/batch/cobalt/cobalt.mustache
+++ b/src/psij/executors/batch/cobalt/cobalt.mustache
@@ -46,9 +46,14 @@ only results in empty files that are not cleaned up}}
 #COBALT -e /dev/null
 #COBALT -o /dev/null
 
+{{> batch_lib}}
+
 {{!like PBS, this is also cheap and there is not need to check setting}}
 PSIJ_NODEFILE="$COBALT_NODEFILE"
 export PSIJ_NODEFILE
+
+{{> stagein}}
+update_status ACTIVE
 
 {{!redirect output here instead of through #COBALT directive since COBALT_JOB_ID is not available
 when the directives are evaluated; the reason for using the job id in the first place being the
@@ -56,6 +61,10 @@ same as for the exit code file.}}
 exec &>> "{{psij.script_dir}}/$COBALT_JOBID.out"
 
 {{#psij.launch_command}}{{.}} {{/psij.launch_command}}
+_PSIJ_JOB_EC=$?
+
+{{> stageout}}
+{{> cleanup}}
 
 {{!we redirect to a file tied to the native ID so that we can reach the file with attach().}}
-echo "$?" > "{{psij.script_dir}}/$COBALT_JOBID.ec"
+echo $_PSIJ_JOB_EC > "{{psij.script_dir}}/$COBALT_JOBID.ec"

--- a/src/psij/executors/batch/common/batch_lib.mustache
+++ b/src/psij/executors/batch/common/batch_lib.mustache
@@ -4,23 +4,50 @@ update_status() {
     STATUS="$1"
     if [ "$_UPDATE_MODE" == "none" ]; then
         if which nc >/dev/null; then
-            $_UPDATE_MODE="nc"
+            _UPDATE_MODE="nc"
         else
-            $_UPDATE_MODE="file"
+            _UPDATE_MODE="file"
         fi
     fi
 
     if [ "$_UPDATE_MODE" == "nc" ]; then
-        for ADDR in "{{psij.us_addrs}}"; do
-            echo "{{psij.job_id}} $STATUS" | nc -q0 -w0 -4 -u $ADDR {{psij.us_port}}
+        ADDRS={{psij.us_addrs}}
+        for ADDR in ${ADDRS//,/ }; do
+            echo "{{job.id}} $STATUS" | nc -q0 -w0 -4 -u $ADDR {{psij.us_port}}
         done
     else
-        echo "{{psij.job_id}} $STATUS" >> {{psij.us_file}}
+        echo "{{job.id}} $STATUS" >> {{psij.us_file}}
+    fi
+}
+
+fail() {
+    [ "{{psij.debug}}" != "0" ] && update_status "LOG Failing: $2"
+    echo $2
+    exit $1
+}
+
+check_remote() {
+    SCHEME="$1"
+    HOSTPORT="$2"
+
+    if [ "$SCHEME" != "" ] && [ "$SCHEME" != "file" ]; then
+        fail 121 "$SCHEME staging is not supported"
+    fi
+    if [ "$HOSTPORT" != "" ] && [ "$HOSTPORT" != "localhost" ]; then
+        fail 121 "The host, if specified, must be \"localhost\". Got \"$HOSTPORT\"."
     fi
 }
 
 do_stagein() {
-    do_stage "$@" 0
+    SOURCE="$1"
+    TARGET="$2"
+    MODE="$3"
+    SCHEME="$6"
+    HOSTPORT="$7"
+
+    check_remote "$SCHEME" "$HOSTPORT" || exit $?
+
+    do_stage "$SOURCE" "$TARGET" "$MODE" 0
 }
 
 do_stage() {
@@ -29,20 +56,43 @@ do_stage() {
     MODE="$3"
     MISSING_OK="$4"
 
-    if [ ! -a "$SOURCE" ] && [ "$MISSING_OK" == "0" ]; then
-        echo "Missing source file: $SOURCE"
-        exit 1
+    [ "{{psij.debug}}" != "0" ] && update_status "LOG Stage $SOURCE -> $TARGET, mode: $MODE, missingok: $MISSING_OK"
+
+    if [ ! -e "$SOURCE" ]; then
+        if [ "$MISSING_OK" == "0" ]; then
+            [ "{{psij.debug}}" != "0" ] && update_status "LOG Missing source file: $SOURCE"
+            fail 121 "Missing source file: $SOURCE"
+        else
+            [ "{{psij.debug}}" != "0" ] && update_status "LOG Skipping staging of missing file $SOURCE"
+            return 0
+        fi
+    fi
+
+    [ "{{psij.debug}}" != "0" ] && update_status "LOG Staging $SOURCE to $TARGET"
+
+    TARGET_DIR=`dirname "$TARGET"`
+
+    if [ "$TARGET_DIR" != "" ]; then
+        mkdir -p "$TARGET_DIR"
+    fi
+
+    if [ -d "$TARGET" ] && [ ! -d "$SOURCE" ]; then
+        fail 121 "Target is a directory: $TARGET"
     fi
 
     if [ "$MODE" == "1" ]; then
         # copy
-        cp -r -T "$SOURCE" "$TARGET"
-    elif [ "$MODE" == "2" ]; tben
+        cp -r -T "$SOURCE" "$TARGET" || fail 121 "Failed to copy \"$SOURCE\" to \"$TARGET\""
+    elif [ "$MODE" == "2" ]; then
         # link
-        ln -s "$SOURCE" "$TARGET"
+        {{!we want the same semantics as cp and mv, which is "overwrite if exists"}}
+        {{!we resolve the source since it may be a path relative to the job dir}}
+        rm -f "$TARGET"
+        SOURCE=`readlink -m $SOURCE`
+        ln -s "$SOURCE" "$TARGET"  || fail 121 "Failed to link \"$SOURCE\" to \"$TARGET\""
     elif [ "$MODE" == "3" ]; then
         # move
-        mv -T -f "$SOURCE" "$TARGET"
+        mv -T -f "$SOURCE" "$TARGET" || fail 121 "Failed to move \"$SOURCE\" to \"$TARGET\""
     fi
 }
 
@@ -57,24 +107,46 @@ do_stageout() {
     MODE="$3"
     FLAGS="$4"
     FAILED="$5"
+    SCHEME="$6"
+    HOSTPORT="$7"
 
-    if [ "$FAILED" == "0" ] && $((FLAGS & _FLAG_ON_SUCCESS)) ; then
+    check_remote "$SCHEME" "$HOSTPORT"
+
+    [ "{{psij.debug}}" != "0" ] && update_status "LOG do_stageout $SOURCE -> $TARGET, mode: $MODE, flags: $FLAGS, failed: $FAILED"
+
+    if [ "$FAILED" == "0" ] && [ "$((FLAGS & _FLAG_ON_SUCCESS))" != "0" ]; then
         do_stage "$SOURCE" "$TARGET" "$MODE" $((FLAGS & _FLAG_IF_PRESENT))
-    elif [ "$FAILED" != "0" ] && $((FLAGS & _FLAG_ON_ERROR)) ; then
+    elif [ "$FAILED" != "0" ] && [ "$((FLAGS & _FLAG_ON_ERROR))" != "0" ]; then
         do_stage "$SOURCE" "$TARGET" "$MODE" $((FLAGS & _FLAG_IF_PRESENT))
     fi
 }
 
 do_cleanup() {
     TARGET="$1"
+    FAILED="$2"
 
-    case "$TARGET" in
-        "{{job.spec.directory}}"*)
-            echo "rm -rf $TARGET" >>~/cleanup.log
-            ;;
-        *)
-            echo "Cannot clean $TARGET outside of job directory {{job.spec.directory}}"
-            exit 1
-            ;;
-    esac
+    if [ "$FAILED" == "0" ] || [ "{{job.spec.cleanup_on_failure}}" != "0" ]; then
+
+        TARGET=`readlink -m "$TARGET"`
+
+        [ "{{psij.debug}}" != "0" ] && update_status "LOG Cleaning up $TARGET"
+
+        case "$TARGET" in
+            "{{job.spec.directory}}"*)
+                rm -rf "$TARGET"
+                ;;
+            *)
+                fail 121 "Cannot clean $TARGET outside of job directory {{job.spec.directory}}"
+                ;;
+        esac
+    fi
+}
+
+stagein() {
+    update_status STAGE_IN
+
+{{#job.spec.stage_in}}
+    do_stagein "{{source.path}}" "{{target}}" {{mode}} \
+        "{{{source.scheme}}}" "{{#source.hostname}}{{{.}}}{{#source.port}}:{{{.}}}{{/source.port}}{{/source.hostname}}"
+{{/job.spec.stage_in}}
 }

--- a/src/psij/executors/batch/common/batch_lib.mustache
+++ b/src/psij/executors/batch/common/batch_lib.mustache
@@ -1,0 +1,80 @@
+_UPDATE_MODE="none"
+
+update_status() {
+    STATUS="$1"
+    if [ "$_UPDATE_MODE" == "none" ]; then
+        if which nc >/dev/null; then
+            $_UPDATE_MODE="nc"
+        else
+            $_UPDATE_MODE="file"
+        fi
+    fi
+
+    if [ "$_UPDATE_MODE" == "nc" ]; then
+        for ADDR in "{{psij.us_addrs}}"; do
+            echo "{{psij.job_id}} $STATUS" | nc -q0 -w0 -4 -u $ADDR {{psij.us_port}}
+        done
+    else
+        echo "{{psij.job_id}} $STATUS" >> {{psij.us_file}}
+    fi
+}
+
+do_stagein() {
+    do_stage "$@" 0
+}
+
+do_stage() {
+    SOURCE="$1"
+    TARGET="$2"
+    MODE="$3"
+    MISSING_OK="$4"
+
+    if [ ! -a "$SOURCE" ] && [ "$MISSING_OK" == "0" ]; then
+        echo "Missing source file: $SOURCE"
+        exit 1
+    fi
+
+    if [ "$MODE" == "1" ]; then
+        # copy
+        cp -r -T "$SOURCE" "$TARGET"
+    elif [ "$MODE" == "2" ]; tben
+        # link
+        ln -s "$SOURCE" "$TARGET"
+    elif [ "$MODE" == "3" ]; then
+        # move
+        mv -T -f "$SOURCE" "$TARGET"
+    fi
+}
+
+_FLAG_IF_PRESENT=1
+_FLAG_ON_SUCCESS=2
+_FLAG_ON_ERROR=4
+_FLAG_ON_CANCEL=8
+
+do_stageout() {
+    SOURCE="$1"
+    TARGET="$2"
+    MODE="$3"
+    FLAGS="$4"
+    FAILED="$5"
+
+    if [ "$FAILED" == "0" ] && $((FLAGS & _FLAG_ON_SUCCESS)) ; then
+        do_stage "$SOURCE" "$TARGET" "$MODE" $((FLAGS & _FLAG_IF_PRESENT))
+    elif [ "$FAILED" != "0" ] && $((FLAGS & _FLAG_ON_ERROR)) ; then
+        do_stage "$SOURCE" "$TARGET" "$MODE" $((FLAGS & _FLAG_IF_PRESENT))
+    fi
+}
+
+do_cleanup() {
+    TARGET="$1"
+
+    case "$TARGET" in
+        "{{job.spec.directory}}"*)
+            echo "rm -rf $TARGET" >>~/cleanup.log
+            ;;
+        *)
+            echo "Cannot clean $TARGET outside of job directory {{job.spec.directory}}"
+            exit 1
+            ;;
+    esac
+}

--- a/src/psij/executors/batch/common/cleanup.mustache
+++ b/src/psij/executors/batch/common/cleanup.mustache
@@ -1,0 +1,5 @@
+update_status CLEANUP
+
+{{#job.spec.cleanup}}
+do_cleanup {{.}} $_PSIJ_JOB_EC
+{{/job.spec.cleanup}}

--- a/src/psij/executors/batch/common/stagein.mustache
+++ b/src/psij/executors/batch/common/stagein.mustache
@@ -1,0 +1,5 @@
+update_status STAGE_IN
+{{#job.spec.stage_in}}
+do_stagein "{{source.path}}" "{{target}}" {{mode}} \
+    "{{{source.scheme}}}" "{{#source.hostname}}{{{.}}}{{#source.port}}:{{{.}}}{{/source.port}}{{/source.hostname}}"
+{{/job.spec.stage_in}}

--- a/src/psij/executors/batch/common/stageout.mustache
+++ b/src/psij/executors/batch/common/stageout.mustache
@@ -1,0 +1,5 @@
+update_status STAGE_OUT
+{{#job.spec.stage_out}}
+do_stageout "{{source}}" "{{target.path}}" {{mode}} {{flags}} $_PSIJ_JOB_EC \
+    "{{{target.scheme}}}" "{{#target.hostname}}{{{.}}}{{#target.port}}:{{{.}}}{{/target.port}}{{/target.hostname}}"
+{{/job.spec.stage_out}}

--- a/src/psij/executors/batch/lsf/lsf.mustache
+++ b/src/psij/executors/batch/lsf/lsf.mustache
@@ -71,8 +71,13 @@ only results in empty files that are not cleaned up}}
 #BSUB -e /dev/null
 #BSUB -o /dev/null
 
+{{> batch_lib}}
+
 PSIJ_NODEFILE="$LSB_HOSTS"
 export PSIJ_NODEFILE
+
+{{> stagein}}
+update_status ACTIVE
 
 {{!redirect output here instead of through #BSUB directive since LSB_JOBID is not available
 when the directives are evaluated; the reason for using the job id in the first place being the
@@ -80,6 +85,10 @@ same as for the exit code file.}}
 exec &>> "{{psij.script_dir}}/$LSB_JOBID.out"
 
 {{#psij.launch_command}}{{.}} {{/psij.launch_command}}
+_PSIJ_JOB_EC=$?
+
+{{> stageout}}
+{{> cleanup}}
 
 {{!we redirect to a file tied to the native ID so that we can reach the file with attach().}}
-echo "$?" > "{{psij.script_dir}}/$LSB_JOBID.ec"
+echo $_PSIJ_JOB_EC > "{{psij.script_dir}}/$LSB_JOBID.ec"

--- a/src/psij/executors/batch/pbs/pbs_classic.mustache
+++ b/src/psij/executors/batch/pbs/pbs_classic.mustache
@@ -55,17 +55,25 @@ only results in empty files that are not cleaned up}}
 #PBS -v {{name}}={{value}}
 {{/env}}
 
+{{> batch_lib}}
+
 PSIJ_NODEFILE="$PBS_NODEFILE"
 export PSIJ_NODEFILE
-
 
 {{#job.spec.directory}}
 cd "{{.}}"
 {{/job.spec.directory}}
 
+{{> stagein}}
+update_status ACTIVE
+
 exec &>> "{{psij.script_dir}}/$PBS_JOBID.out"
 
 {{#psij.launch_command}}{{.}} {{/psij.launch_command}}
+_PSIJ_JOB_EC=$?
+
+{{> stageout}}
+{{> cleanup}}
 
 {{!we redirect to a file tied to the native ID so that we can reach the file with attach().}}
-echo "$?" > "{{psij.script_dir}}/$PBS_JOBID.ec"
+echo $_PSIJ_JOB_EC > "{{psij.script_dir}}/$PBS_JOBID.ec"

--- a/src/psij/executors/batch/pbs/pbspro.mustache
+++ b/src/psij/executors/batch/pbs/pbspro.mustache
@@ -58,17 +58,25 @@ only results in empty files that are not cleaned up}}
 #PBS -v {{name}}={{value}}
 {{/env}}
 
+{{> batch_lib}}
+
 PSIJ_NODEFILE="$PBS_NODEFILE"
 export PSIJ_NODEFILE
-
 
 {{#job.spec.directory}}
 cd "{{.}}"
 {{/job.spec.directory}}
 
+{{> stagein}}
+update_status ACTIVE
+
 exec &>> "{{psij.script_dir}}/$PBS_JOBID.out"
 
 {{#psij.launch_command}}{{.}} {{/psij.launch_command}}
+_PSIJ_JOB_EC=$?
+
+{{> stageout}}
+{{> cleanup}}
 
 {{!we redirect to a file tied to the native ID so that we can reach the file with attach().}}
 echo "$?" > "{{psij.script_dir}}/$PBS_JOBID.ec"

--- a/src/psij/executors/batch/script_generator.py
+++ b/src/psij/executors/batch/script_generator.py
@@ -1,11 +1,22 @@
 import pathlib
 from abc import ABC
-from typing import Dict, Callable, IO
+from enum import Enum
+from typing import Dict, Callable, IO, Optional
 
 import pystache
 
 from psij import Job, JobExecutorConfig
 from .escape_functions import bash_escape
+
+
+class _Renderer(pystache.Renderer):  # type: ignore
+    def str_coerce(self, val: object) -> str:
+        if isinstance(val, Enum):
+            return str(val.value)
+        elif isinstance(val, bool):
+            return str(int(val))
+        else:
+            return super().str_coerce(val)  # type: ignore
 
 
 class SubmitScriptGenerator(ABC):
@@ -16,7 +27,7 @@ class SubmitScriptGenerator(ABC):
     script specific to a certain batch scheduler.
     """
 
-    def __init__(self, config: JobExecutorConfig) -> None:
+    def __init__(self, config: Optional[JobExecutorConfig]) -> None:
         """
         Parameters
         ----------
@@ -56,7 +67,7 @@ class TemplatedScriptGenerator(SubmitScriptGenerator):
     implementation of the Mustache templating language (https://mustache.github.io/).
     """
 
-    def __init__(self, config: JobExecutorConfig, template_path: pathlib.Path,
+    def __init__(self, config: Optional[JobExecutorConfig], template_path: pathlib.Path,
                  escape: Callable[[object], str] = bash_escape) -> None:
         """
         Parameters
@@ -73,7 +84,7 @@ class TemplatedScriptGenerator(SubmitScriptGenerator):
         with template_path.open('r') as template_file:
             self.template = pystache.parse(template_file.read())
         common_dir = pathlib.Path(__file__).parent / 'common'
-        self.renderer = pystache.Renderer(escape=escape, search_dirs=[str(common_dir)])
+        self.renderer = _Renderer(escape=escape, search_dirs=[str(common_dir)])
 
     def generate_submit_script(self, job: Job, context: Dict[str, object], out: IO[str]) -> None:
         """See :func:`~SubmitScriptGenerator.generate_submit_script`.

--- a/src/psij/executors/batch/script_generator.py
+++ b/src/psij/executors/batch/script_generator.py
@@ -72,7 +72,8 @@ class TemplatedScriptGenerator(SubmitScriptGenerator):
         super().__init__(config)
         with template_path.open('r') as template_file:
             self.template = pystache.parse(template_file.read())
-        self.renderer = pystache.Renderer(escape=escape)
+        common_dir = pathlib.Path(__file__).parent / 'common'
+        self.renderer = pystache.Renderer(escape=escape, search_dirs=[str(common_dir)])
 
     def generate_submit_script(self, job: Job, context: Dict[str, object], out: IO[str]) -> None:
         """See :func:`~SubmitScriptGenerator.generate_submit_script`.

--- a/src/psij/executors/batch/slurm/slurm.mustache
+++ b/src/psij/executors/batch/slurm/slurm.mustache
@@ -88,6 +88,8 @@ _PSIJ_PPN={{.}}
     {{/processes_per_node}}
 {{/job.spec.resources}}
 
+{{> batch_lib}}
+
 _PSIJ_NC=`scontrol show hostnames | wc -l`
 
 {{!Unlike PBS, Slurm only lists the nodes once in the nodelist, so, to bring it to uniform PBS
@@ -106,7 +108,8 @@ else
 fi
 export PSIJ_NODEFILE
 
-
+{{> stagein}}
+update_status ACTIVE
 
 {{!redirect output here instead of through #SBATCH directive since SLURM_JOB_ID is not available
 when the directives are evaluated; the reason for using the job id in the first place being the
@@ -114,6 +117,10 @@ same as for the exit code file.}}
 exec &>> "{{psij.script_dir}}/$SLURM_JOB_ID.out"
 
 {{#psij.launch_command}}{{.}} {{/psij.launch_command}}
+_PSIJ_JOB_EC=$?
+
+{{> stageout}}
+{{> cleanup}}
 
 {{!we redirect to a file tied to the native ID so that we can reach the file with attach().}}
-echo "$?" > "{{psij.script_dir}}/$SLURM_JOB_ID.ec"
+echo $_PSIJ_JOB_EC > "{{psij.script_dir}}/$SLURM_JOB_ID.ec"

--- a/src/psij/executors/local.py
+++ b/src/psij/executors/local.py
@@ -1,22 +1,26 @@
 """This module contains the local :class:`~psij.JobExecutor`."""
 import logging
 import os
+import pathlib
+import platform
 import shlex
+import shutil
 import signal
 import subprocess
 import threading
 import time
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from tempfile import mkstemp
-from types import FrameType
-from typing import Optional, Dict, List, Tuple, Type, cast
+from typing import Optional, Dict, List, Tuple, TypeVar, Set, Callable
 
 import psutil
+from psutil import NoSuchProcess
 
-from psij import InvalidJobException, SubmitException, Launcher, ResourceSpecV1
+from psij import InvalidJobException, SubmitException, ResourceSpecV1
 from psij import Job, JobSpec, JobExecutorConfig, JobState, JobStatus
 from psij import JobExecutor
-from psij.utils import SingletonThread
+from psij.exceptions import CompositeException, LauncherException, JobException
+from psij.staging import StageIn, StagingMode, StageOut, StageOutFlags
 
 logger = logging.getLogger(__name__)
 
@@ -30,91 +34,317 @@ def _format_shell_cmd(args: List[str]) -> str:
     return cmd
 
 
-def _handle_sigchld(signum: int, frame: Optional[FrameType]) -> None:
-    _ProcessReaper.get_instance()._handle_sigchld()
-
-
-if threading.current_thread() != threading.main_thread():
-    logger.warning('The psij module is being imported from a non-main thread. This prevents the'
-                   'use of signals in the local executor, which will slow things down a bit.')
-else:
-    signal.signal(signal.SIGCHLD, _handle_sigchld)
-
-
-_REAPER_SLEEP_TIME = 0.1
-
-
-class _ProcessEntry(ABC):
-    def __init__(self, job: Job, executor: 'LocalJobExecutor', launcher: Optional[Launcher]):
-        self.job = job
+class _JobThread(threading.Thread):
+    def __init__(self, job: Job, executor: JobExecutor) -> None:
+        super().__init__(name = 'LocalJobThread-' + job.id)
         self.executor = executor
-        self.exit_code: Optional[int] = None
-        self.done_time: Optional[float] = None
-        self.out: Optional[str] = None
-        self.kill_flag = False
-        self.process: Optional[subprocess.Popen[bytes]] = None
-        self.launcher = launcher
+        self.cancel_flag = False
 
     @abstractmethod
-    def kill(self) -> None:
-        assert self.process is not None
-        root = psutil.Process(self.process.pid)
-        for proc in root.children(recursive=True):
-            proc.kill()
-        self.process.kill()
-
-    @abstractmethod
-    def poll(self) -> Tuple[Optional[int], Optional[str]]:
+    def cancel(self):
         pass
 
-    def __repr__(self) -> str:
-        pid = '-'
-        if self.process:
-            pid = str(self.process.pid)
-        return '{}[jobid: {}, pid: {}]'.format(self.__class__.__name__, self.job.id, pid)
-
-
-class _ChildProcessEntry(_ProcessEntry):
-    def __init__(self, job: Job, executor: 'LocalJobExecutor',
-                 launcher: Optional[Launcher]) -> None:
-        super().__init__(job, executor, launcher)
-        self.nodefile: Optional[str] = None
-
-    def kill(self) -> None:
-        super().kill()
-
-    def poll(self) -> Tuple[Optional[int], Optional[str]]:
-        assert self.process is not None
-        exit_code = self.process.poll()
-        if exit_code is not None:
-            if self.nodefile:
-                os.unlink(self.nodefile)
-            if self.process.stdout:
-                return exit_code, self.process.stdout.read().decode('utf-8')
+    def _get_state_from_ec(self, ec: int) -> Tuple[JobState, Optional[Exception]]:
+        if ec is None or ec == 0:
+            return JobState.COMPLETED, None
+        elif ec < 0:
+            if self.cancel_flag:
+                return JobState.CANCELED, None
             else:
-                return exit_code, None
+                return JobState.FAILED, JobException(ec)
         else:
-            return None, None
-
-
-class _AttachedProcessEntry(_ProcessEntry):
-    def __init__(self, job: Job, process: psutil.Process, executor: 'LocalJobExecutor'):
-        super().__init__(job, executor, None)
-        self.process = process
-
-    def kill(self) -> None:
-        super().kill()
-
-    def poll(self) -> Tuple[Optional[int], Optional[str]]:
-        try:
-            assert self.process
-            ec: Optional[int] = self.process.wait(timeout=0)
-            if ec is None:
-                return 0, None
+            # ec > 0
+            # It is not quite clear what happens in Windows. Windows allows the user
+            # to specify an exit code when killing a process, exit code which will become
+            # the exit code of the terminated process. However, psutil does not specify what
+            # is being done for that on Windows. The psutil sources suggest that signal.SIGTERM
+            # is used, so we check for that.
+            if platform.system() == 'Windows' and ec == signal.SIGTERM and self.cancel_flag:
+                return JobState.CANCELED, None
             else:
-                return ec, None
-        except psutil.TimeoutExpired:
-            return None, None
+                return JobState.FAILED, JobException(ec)
+
+
+# The addition of file staging makes fully asynchronous job management difficult, since we don't
+# really have much in the way of something reasonably supporting true async file copying. So since
+# we have to use threads anyway, and since the local executor is not really meant to scale, we use
+# them for attached processes also.
+class _AttachedJobThread(_JobThread):
+    def __init__(self, job: Job, pid: int, executor: JobExecutor) -> None:
+        super().__init__(job, executor)
+        self.job = job
+        self.pid = pid
+        self._attach()
+
+    def _attach(self):
+        with self.job._status_cv:
+            try:
+                self.process = psutil.Process(self.pid)
+            except NoSuchProcess:
+                # will check in run() and set status
+                self.process = None
+            except Exception as ex:
+                raise SubmitException('Cannot attach to pid %s' % self.pid, exception=ex)
+
+    def run(self) -> None:
+        # We assume that the native_id above is a PID that was obtained at some point using
+        # list(). If so, the process is either still running or has completed. Either way, we must
+        # bring it up to ACTIVE state
+        self.executor._set_job_status(self.job, JobStatus(JobState.QUEUED, time=time.time()))
+        self.executor._set_job_status(self.job, JobStatus(JobState.ACTIVE, time=time.time()))
+        try:
+            self._wait_for_job()
+        except Exception:
+            pass
+
+    def _wait_for_job(self):
+        message = None
+        if self.process is None:
+            state = JobState.COMPLETED
+        else:
+            ec = self.process.wait()
+            state = self._get_state_from_ec(ec)
+
+            if state == JobState.FAILED:
+                message = 'Job failed with exit code %s' % ec
+
+        self.executor._set_job_status(self.job, JobStatus(state, message=message, time=time.time()))
+
+    def cancel(self):
+        with self.job._status_cv:
+            self.cancel_flag = True
+            if self.process:
+                self.process.kill()
+
+
+class _JobCanceled(Exception):
+    pass
+
+
+T = TypeVar('T')
+
+
+class _ChildJobThread(_JobThread):
+
+    FLAG_MAP = {JobState.COMPLETED: StageOutFlags.ON_SUCCESS,
+                JobState.FAILED: StageOutFlags.ON_ERROR,
+                JobState.CANCELED: StageOutFlags.ON_CANCEL}
+
+    def __init__(self, job: Job, spec: JobSpec, executor: JobExecutor) -> None:
+        super().__init__(job, executor)
+        self.job = job
+        self.spec = spec
+        if spec.directory is None:
+            self.jobdir = pathlib.Path('/tmp')
+        else:
+            self.jobdir = spec.directory
+        self.state = None
+        # set for any error; the overall job is automatically considered failed if set
+        self.exception = None
+        self.exit_code = None
+        self.process = None
+
+    def run(self):
+        # The following workflow is based on the idea that no error should go unreported. The
+        # flow is as follows:
+        # - if there is an error in staging, fail immediately (i.e., do not perform cleanup or
+        # any other steps).
+        # - if there is an internal error (i.e., not an executable failure), treat as above and
+        # fail immediately
+        # - if a job is canceled during stage in, clean up. If there is an error in cleanup,
+        # the job will fail instead.
+        # - if a job is canceled while running, stage out and clean up. If there is an error in
+        # stage out and/or cleanup, the job will instead fail.
+        # - if the job fails and there is a subsequent error in staging or cleanup, a compound
+        # error is created
+        # - cancellation is ignored during and after stageout
+
+        try:
+            try:
+                self.stage_in()
+                self.run_job()
+                self.stage_out()
+            except _JobCanceled:
+                # only stage_in and run_job (but before the job is actually started)
+                # are allowed to raise _JobCanceled
+                self.state = JobState.CANCELED
+            self.cleanup()
+        except Exception as ex:
+            self.fail_job(ex)
+
+        self.update_job_status()
+
+    def update_job_status(self):
+        if self.exception:
+            self.executor._set_job_status(self.job,
+                                          JobStatus(JobState.FAILED, time=time.time(),
+                                                    message=str(self.exception),
+                                                    metadata={'exception': self.exception},
+                                                    exit_code=self.exit_code))
+        else:
+            # failed without an exception set is not allowed
+            assert self.state != JobState.FAILED
+            self.executor._set_job_status(self.job, JobStatus(self.state, time=time.time()))
+
+    def fail_job(self, ex: Exception) -> None:
+        if self.state == JobState.FAILED:
+            if self.exception is None:
+                self.exception = ex
+            else:
+                if not isinstance(self.exception, CompositeException):
+                    self.exception = CompositeException(self.exception)
+                self.exception.add_exception(ex)
+        else:
+            self.state = JobState.FAILED
+            self.exception = ex
+
+    def stage_in(self) -> None:
+        self.executor._set_job_status(self.job, JobStatus(JobState.STAGE_IN, time=time.time()))
+        self._map(self._stage_in_one, self.spec.stage_in)
+
+    def stage_out(self):
+        self.executor._set_job_status(self.job, JobStatus(JobState.STAGE_OUT, time=time.time()))
+        self._map(self._stage_out_one, self.spec.stage_out)
+
+    def cleanup(self):
+        self.executor._set_job_status(self.job, JobStatus(JobState.CLEANUP, time=time.time()))
+        self._map(self._cleanup_one, self.spec.cleanup)
+
+    @staticmethod
+    def _map(fn: Callable[[T], None], s: Optional[Set[T]], ) -> None:
+        if s is None:
+            return
+        for o in s:
+            fn(o)
+
+    def _stage_in_one(self, stage_in: StageIn) -> None:
+        if self.cancel_flag:
+            raise _JobCanceled()
+        src = stage_in.source
+        scheme = src.scheme
+        if scheme == '':
+            scheme = 'file'
+        if scheme == 'file':
+            self._local_copy(pathlib.Path(src.path), self._job_rel(stage_in.target),
+                             stage_in.mode, False)
+        else:
+            self.fail_job(ValueError('Unsupported scheme "%s" for %s' % (scheme, src)))
+
+    def _stage_out_one(self, stage_out: StageOut) -> None:
+        dst = stage_out.target
+        scheme = dst.scheme
+        if scheme == '':
+            scheme = 'file'
+        if scheme == 'file':
+            flags = stage_out.flags
+            state = _ChildJobThread.FLAG_MAP[self.state]
+            if state in flags:
+                self._local_copy(self._job_rel(stage_out.source), pathlib.Path(dst.path),
+                                 stage_out.mode, StageOutFlags.IF_PRESENT in stage_out.flags)
+        else:
+            self.fail_job(ValueError('Unsupported scheme "%s" for %s' % (scheme, dst)))
+
+    def _cleanup_one(self, cleanup: pathlib.Path) -> None:
+        # do some sanity checks
+        cleanup = self._job_rel(cleanup)
+        if cleanup.samefile(pathlib.Path('/')):
+            raise ValueError('Refusing to clean root directory.')
+        if cleanup.samefile(pathlib.Path.home()):
+            raise ValueError('Refusing to clean user home directory.')
+        if cleanup.is_dir():
+            shutil.rmtree(str(cleanup))
+        else:
+            cleanup.unlink(missing_ok=True)
+
+    def _job_rel(self, path: pathlib.Path) -> pathlib.Path:
+        path = path.expanduser()
+        if not path.is_absolute():
+            path = self.jobdir / path
+        return path.absolute()
+
+    def _local_copy(self, source: pathlib.Path, target: pathlib.Path, mode: StagingMode,
+                    if_present=False):
+        if if_present and not os.path.exists(source):
+            return
+        if mode == StagingMode.COPY:
+            if source.is_dir():
+                shutil.copytree(source, target)
+            else:
+                shutil.copy(source, target)
+        elif mode == StagingMode.MOVE:
+            shutil.move(source, target)
+        elif mode == StagingMode.LINK:
+            os.symlink(source, target)
+
+    def run_job(self):
+        launcher = self.executor._get_launcher(self._get_launcher_name(self.spec))
+        args = launcher.get_launch_command(self.job)
+
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug('Running %s', _format_shell_cmd(args))
+        nodefile = self._generate_nodefile(self.job)
+        try:
+            env = _get_env(self.spec, nodefile)
+            with self.job._status_cv:
+                if self.cancel_flag:
+                    raise _JobCanceled()
+                self.process = subprocess.Popen(args, stdout=subprocess.PIPE,
+                                                stderr=subprocess.STDOUT, close_fds=True,
+                                                cwd=self.spec.directory, env=env)
+            self.job._native_id = self.process.pid
+            self.executor._set_job_status(self.job,
+                                          JobStatus(JobState.ACTIVE, time=time.time(),
+                                                    metadata={'nativeId': self.job._native_id}))
+            self.exit_code = self.process.wait()
+
+            # We want to capture errors in the launcher scripts. Since, under normal circumstances,
+            # the exit code of the launcher is the exit code of the job, we must use a different
+            # mechanism to distinguish between job errors and launcher errors. So we delegate to
+            # the launcher implementation to figure out if the error belongs to the job or not
+            if self.process.stdout:
+                out = self.process.stdout.read().decode('utf-8')
+            else:
+                out = None
+            if out and launcher.is_launcher_failure(out):
+                message = self.process.launcher.get_launcher_failure_message(out)
+                self.fail_job(LauncherException(message))
+            else:
+                self.state, self.exception = self._get_state_from_ec(self.exit_code)
+        finally:
+            if nodefile:
+                os.remove(nodefile)
+
+    def cancel(self):
+        with self.job._status_cv:
+            self.cancel_flag = True
+            if self.process is not None:
+                self.process.kill()
+
+    def _generate_nodefile(self, job: Job) -> Optional[str]:
+        assert job.spec is not None
+        if job.spec.resources is None:
+            return None
+        if job.spec.resources.version == 1:
+            assert isinstance(job.spec.resources, ResourceSpecV1)
+            n = job.spec.resources.computed_process_count
+            if n == 1:
+                # as a bit of an optimization, we don't generate a nodefile when doing "single
+                # node" jobs on local.
+                return None
+            (file, nodefile) = mkstemp(suffix='.nodelist')
+            for i in range(n):
+                os.write(file, 'localhost\n'.encode())
+            os.close(file)
+            return nodefile
+        else:
+            raise SubmitException('Cannot handle resource specification with version %s'
+                                  % job.spec.resources.version)
+
+    def _get_launcher_name(self, spec: JobSpec) -> str:
+        if spec.launcher is None:
+            return 'single'
+        else:
+            return spec.launcher
 
 
 def _get_env(spec: JobSpec, nodefile: Optional[str]) -> Optional[Dict[str, str]]:
@@ -141,80 +371,6 @@ def _get_env(spec: JobSpec, nodefile: Optional[str]) -> Optional[Dict[str, str]]
                 env.update(spec.environment)
 
         return env
-
-
-class _ProcessReaper(SingletonThread):
-
-    @classmethod
-    def get_instance(cls: Type['_ProcessReaper']) -> '_ProcessReaper':
-        return cast('_ProcessReaper', super().get_instance())
-
-    def __init__(self) -> None:
-        super().__init__(name='Local Executor Process Reaper', daemon=True)
-        self._jobs: Dict[Job, _ProcessEntry] = {}
-        self._lock = threading.RLock()
-        self._cvar = threading.Condition()
-
-    def register(self, entry: _ProcessEntry) -> None:
-        logger.debug('Registering process %s', entry)
-        with self._lock:
-            self._jobs[entry.job] = entry
-
-    def run(self) -> None:
-        logger.debug('Started {}'.format(self))
-        done: List[_ProcessEntry] = []
-        while True:
-            with self._lock:
-                for entry in done:
-                    del self._jobs[entry.job]
-                jobs = dict(self._jobs)
-            try:
-                done = self._check_processes(jobs)
-            except Exception as ex:
-                logger.error('Error polling for process status', ex)
-            with self._cvar:
-                self._cvar.wait(_REAPER_SLEEP_TIME)
-
-    def _handle_sigchld(self) -> None:
-        with self._cvar:
-            try:
-                self._cvar.notify_all()
-            except RuntimeError:
-                # In what looks like rare cases, notify_all(), seemingly when combined with
-                # signal handling, raises `RuntimeError: release unlocked lock`.
-                # There appears to be an unresolved Python bug about this:
-                #    https://bugs.python.org/issue34486
-                # We catch the exception here and log it. It is hard to tell if that will not lead
-                # to further issues. It would seem like it shouldn't: after all, all we're doing is
-                # making sure we don't sleep too much, but, even if we do, the consequence is a
-                # small delay in processing a completed job. However, since this exception seems
-                # to be a logical impossibility when looking at the code in threading.Condition,
-                # there is really no telling what else could go wrong.
-                logger.debug('Exception in Condition.notify_all()')
-
-    def _check_processes(self, jobs: Dict[Job, _ProcessEntry]) -> List[_ProcessEntry]:
-        done: List[_ProcessEntry] = []
-
-        for entry in jobs.values():
-            if entry.kill_flag:
-                entry.kill()
-
-            exit_code, out = entry.poll()
-            if exit_code is not None:
-                entry.exit_code = exit_code
-                entry.done_time = time.time()
-                entry.out = out
-                done.append(entry)
-
-        for entry in done:
-            entry.executor._process_done(entry)
-
-        return done
-
-    def cancel(self, job: Job) -> None:
-        with self._lock:
-            p = self._jobs[job]
-            p.kill_flag = True
 
 
 class LocalJobExecutor(JobExecutor):
@@ -245,27 +401,8 @@ class LocalJobExecutor(JobExecutor):
         :type config: psij.JobExecutorConfig
         """
         super().__init__(url=url, config=config if config else JobExecutorConfig())
-        self._reaper = _ProcessReaper.get_instance()
-
-    def _generate_nodefile(self, job: Job, p: _ChildProcessEntry) -> Optional[str]:
-        assert job.spec is not None
-        if job.spec.resources is None:
-            return None
-        if job.spec.resources.version == 1:
-            assert isinstance(job.spec.resources, ResourceSpecV1)
-            n = job.spec.resources.computed_process_count
-            if n == 1:
-                # as a bit of an optimization, we don't generate a nodefile when doing "single
-                # node" jobs on local.
-                return None
-            (file, p.nodefile) = mkstemp(suffix='.nodelist')
-            for i in range(n):
-                os.write(file, 'localhost\n'.encode())
-            os.close(file)
-            return p.nodefile
-        else:
-            raise SubmitException('Cannot handle resource specification with version %s'
-                                  % job.spec.resources.version)
+        self._threads_lock = threading.RLock()
+        self.threads: Dict[str, _JobThread] = {}
 
     def submit(self, job: Job) -> None:
         """
@@ -281,27 +418,16 @@ class LocalJobExecutor(JobExecutor):
         """
         spec = self._check_job(job)
 
-        p = _ChildProcessEntry(job, self, self._get_launcher(self._get_launcher_name(spec)))
-        assert p.launcher
-        args = p.launcher.get_launch_command(job)
+        self._set_job_status(job, JobStatus(JobState.QUEUED, time=time.time()))
 
-        try:
-            with job._status_cv:
-                if job.status.state == JobState.CANCELED:
-                    raise SubmitException('Job canceled')
-            if logger.isEnabledFor(logging.DEBUG):
-                logger.debug('Running %s', _format_shell_cmd(args))
-            nodefile = self._generate_nodefile(job, p)
-            env = _get_env(spec, nodefile)
-            p.process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                         close_fds=True, cwd=spec.directory, env=env)
-            self._reaper.register(p)
-            job._native_id = p.process.pid
-            self._set_job_status(job, JobStatus(JobState.QUEUED, time=time.time(),
-                                                metadata={'nativeId': job._native_id}))
-            self._set_job_status(job, JobStatus(JobState.ACTIVE, time=time.time()))
-        except Exception as ex:
-            raise SubmitException('Failed to submit job', exception=ex)
+        with job._status_cv:
+            if job.status.state == JobState.CANCELED:
+                raise SubmitException('Job canceled')
+            job_thread = _ChildJobThread(job, spec, self)
+
+        with self._threads_lock:
+            self.threads[job.id] = job_thread
+            job_thread.start()
 
     def cancel(self, job: Job) -> None:
         """
@@ -309,27 +435,17 @@ class LocalJobExecutor(JobExecutor):
 
         :param job: The job to cancel.
         """
-        self._set_job_status(job, JobStatus(JobState.CANCELED))
-        self._reaper.cancel(job)
 
-    def _process_done(self, p: _ProcessEntry) -> None:
-        assert p.exit_code is not None
-        message = None
-        if p.exit_code == 0:
-            state = JobState.COMPLETED
-        elif p.exit_code < 0 and p.kill_flag:
-            state = JobState.CANCELED
-        else:
-            # We want to capture errors in the launcher scripts. Since, under normal circumstances,
-            # the exit code of the launcher is the exit code of the job, we must use a different
-            # mechanism to distinguish between job errors and launcher errors. So we delegate to
-            # the launcher implementation to figure out if the error belongs to the job or not
-            if p.launcher and p.out and p.launcher.is_launcher_failure(p.out):
-                message = p.launcher.get_launcher_failure_message(p.out)
-            state = JobState.FAILED
-
-        self._set_job_status(p.job, JobStatus(state, time=p.done_time, exit_code=p.exit_code,
-                                              message=message))
+        with self._threads_lock:
+            try:
+                job_thread = self.threads[job.id]
+            except KeyError:
+                raise ValueError('The job %s is not managed by this executor.' % job.id)
+        with job._status_cv:
+            if job_thread is not None:
+                job_thread.cancel()
+            else:
+                self._set_job_status(job, JobStatus(JobState.CANCELED))
 
     def list(self) -> List[str]:
         """
@@ -364,15 +480,11 @@ class LocalJobExecutor(JobExecutor):
         job.executor = self
         pid = int(native_id)
 
-        self._reaper.register(_AttachedProcessEntry(job, psutil.Process(pid), self))
-        # We assume that the native_id above is a PID that was obtained at some point using
-        # list(). If so, the process is either still running or has completed. Either way, we must
-        # bring it up to ACTIVE state
-        self._set_job_status(job, JobStatus(JobState.QUEUED, time=time.time()))
-        self._set_job_status(job, JobStatus(JobState.ACTIVE, time=time.time()))
+        with job._status_cv:
+            if job.status.state == JobState.CANCELED:
+                raise SubmitException('Job canceled')
+            job_thread = _AttachedJobThread(job, pid, self)
 
-    def _get_launcher_name(self, spec: JobSpec) -> str:
-        if spec.launcher is None:
-            return 'single'
-        else:
-            return spec.launcher
+        with self._threads_lock:
+            self.threads[job.id] = job_thread
+            job_thread.start()

--- a/src/psij/executors/local/local.mustache
+++ b/src/psij/executors/local/local.mustache
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+{{> batch_lib}}
+
+{{#job.spec.directory}}
+cd "{{.}}"
+{{/job.spec.directory}}
+
+{{> stagein}}
+update_status ACTIVE
+
+set +e
+{{#job.spec.inherit_environment}}env \{{/job.spec.inherit_environment}}{{^job.spec.inherit_environment}}env --ignore-environment \{{/job.spec.inherit_environment}}{{#env}}
+{{name}}="{{value}}" \{{/env}}
+PSIJ_NODEFILE={{psij.nodefile}} \
+{{#psij.launch_command}}{{.}} {{/psij.launch_command}}
+_PSIJ_JOB_EC="$?"
+set -e
+
+{{> stageout}}
+{{> cleanup}}
+
+exit "$_PSIJ_JOB_EC"

--- a/src/psij/job_state.py
+++ b/src/psij/job_state.py
@@ -2,6 +2,8 @@ from enum import Enum
 from typing import Optional
 
 
+_NAME_MAP = {}
+
 class JobState(bytes, Enum):
     """
     An enumeration holding the possible job states.
@@ -16,6 +18,7 @@ class JobState(bytes, Enum):
         obj._order = order
         obj._name = name
         obj._final = final
+        _NAME_MAP[name] = obj
         return obj
 
     def __init__(self, *args: object) -> None:  # noqa: D107
@@ -34,19 +37,32 @@ class JobState(bytes, Enum):
     This is the state of the job after being accepted by a backend for execution, but before the
     execution of the job begins.
     """
-    ACTIVE = (2, 2, 'ACTIVE', False)
+    STAGE_IN = (2, 2, 'STAGE_IN', False)
+    """
+    This state indicates that the job is staging files in, in preparation for execution.
+    """
+    ACTIVE = (3, 3, 'ACTIVE', False)
     """This state represents an actively running job."""
-    COMPLETED = (3, 3, 'COMPLETED', True)
+    STAGE_OUT = (4, 4, 'STAGE_OUT', False)
+    """
+    This state indicates that the executable has finished running and that files are being staged
+    out.
+    """
+    CLEANUP = (5, 5, 'CLEANUP', False)
+    """
+    This state indicates that cleanup is actively being done for this job.
+    """
+    COMPLETED = (6, 6, 'COMPLETED', True)
     """
     This state represents a job that has completed *successfully* (i.e., with a zero exit code).
     In other words, a job with the executable set to `/bin/false` cannot enter this state.
     """
-    FAILED = (4, 3, 'FAILED', True)
+    FAILED = (7, 6, 'FAILED', True)
     """
     Represents a job that has either completed unsuccessfully (with a non-zero exit code) or a job
     whose handling and/or execution by the backend has failed in some way.
     """
-    CANCELED = (5, 3, 'CANCELED', True)
+    CANCELED = (8, 6, 'CANCELED', True)
     """Represents a job that was canceled by a call to :func:`~psij.Job.cancel()`."""
 
     def is_greater_than(self, other: 'JobState') -> Optional[bool]:
@@ -112,6 +128,22 @@ class JobState(bytes, Enum):
         """Returns a hash for this object."""
         return self._value_  # type: ignore
 
+    @staticmethod
+    def from_name(name: str) -> 'JobState':
+        return _NAME_MAP[name]
+
+
+_PREV_STATE = {
+    JobState.NEW: None,
+    JobState.QUEUED: JobState.NEW,
+    JobState.STAGE_IN: JobState.QUEUED,
+    JobState.ACTIVE: JobState.STAGE_IN,
+    JobState.STAGE_OUT: JobState.ACTIVE,
+    JobState.CLEANUP: JobState.STAGE_OUT,
+    JobState.COMPLETED: JobState.CLEANUP,
+    JobState.FAILED: None,
+    JobState.CANCELED: None
+}
 
 class JobStateOrder:
     """A class that can be used to reconstruct missing states."""
@@ -125,10 +157,4 @@ class JobStateOrder:
         previous state. For example, the FAILED state does not have a previous state, since it can
         be reached from multiple states.
         """
-        if state == JobState.COMPLETED:
-            return JobState.ACTIVE
-        if state == JobState.ACTIVE:
-            return JobState.QUEUED
-        if state == JobState.QUEUED:
-            return JobState.NEW
-        return None
+        return _PREV_STATE[state]

--- a/src/psij/job_state.py
+++ b/src/psij/job_state.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 _NAME_MAP = {}
 
+
 class JobState(bytes, Enum):
     """
     An enumeration holding the possible job states.
@@ -130,6 +131,11 @@ class JobState(bytes, Enum):
 
     @staticmethod
     def from_name(name: str) -> 'JobState':
+        """
+        Returns a `JobState` object corresponding to its string representation.
+
+        This method is such that `state == JobState.from_name(str(state))`.
+        """
         return _NAME_MAP[name]
 
 
@@ -144,6 +150,7 @@ _PREV_STATE = {
     JobState.FAILED: None,
     JobState.CANCELED: None
 }
+
 
 class JobStateOrder:
     """A class that can be used to reconstruct missing states."""

--- a/src/psij/launchers/script_based_launcher.py
+++ b/src/psij/launchers/script_based_launcher.py
@@ -200,8 +200,12 @@ class ScriptBasedLauncher(Launcher):
 
     def is_launcher_failure(self, output: str) -> bool:
         """See :func:`~psij.Launcher.is_launcher_failure`."""
-        return output.split('\n')[-2] != '_PSI_J_LAUNCHER_DONE'
+        lines = output.split('\n')
+        return lines[-2] != '_PSI_J_LAUNCHER_DONE' or lines[-1] != ''
 
     def get_launcher_failure_message(self, output: str) -> str:
         """See :func:`~psij.Launcher.get_launcher_failure_message`."""
-        return '\n'.join(output.split('\n')[:-2])
+        # Errors can occur in the job script after the launcher is done (e.g., stageout),
+        # so we need to filter the launcher tag
+        lines = output.split('\n')
+        return '\n'.join(filter(lambda x: x != '_PSI_J_LAUNCHER_DONE', lines))

--- a/src/psij/staging.py
+++ b/src/psij/staging.py
@@ -1,94 +1,287 @@
-import urllib
+from urllib.parse import urlparse
 from enum import Enum, Flag
 from pathlib import Path
 from typing import Optional, Union
 
 
 class URI:
+    """A class representing a local or remote file."""
+
     def __init__(self, urlstring: str) -> None:
-        self.parts = urllib.parse.urlparse(urlstring)
+        """
+        Parameters
+        ----------
+        urlstring
+            A string representation of a URI, such as "http://example.com/file.txt" or "file.txt".
+            The precise format of an URI string is defined in
+            `RFC3986 <https://datatracker.ietf.org/doc/html/rfc3986.html>`_.
+        """
+        self.parts = urlparse(urlstring)
 
     # a __getattr__ solution may be simpler, but doesn't play well with IDEs and
     # is not quite self-documenting
     @property
     def hostname(self) -> Optional[str]:
-        return self.hostname
+        """
+        Returns
+        -------
+        Represents the hostname in this URI or `None` if no hostname was specified.
+        """
+        return self.parts.hostname
 
     @property
-    def port(self) -> int:
-        return self.port
+    def port(self) -> Optional[int]:
+        """
+        Returns
+        -------
+        Returns the TCP port of this URI or None if a port was not specified.
+        """
+        return self.parts.port
 
     @property
     def scheme(self) -> str:
+        """
+        Returns
+        -------
+        Returns the URI scheme in this URI or the empty string if no scheme was specified.
+        """
         return self.parts.scheme
 
     @property
     def netloc(self) -> str:
+        """
+        Returns
+        -------
+        Returns the network location, which may the host name, the port, and possibly login
+        information. If none of these are specified, the empty string is returned.
+        """
         return self.parts.netloc
 
     @property
     def path(self) -> str:
+        """
+        Returns
+        -------
+        Returns the path in this URI or an empty string if no path was specified.
+        """
         return self.parts.path
 
     @property
     def params(self) -> str:
+        """
+        Returns
+        -------
+        Returns the URI parameters or an empty string if there are no parameters.
+        """
         return self.parts.params
 
     @property
     def query(self) -> str:
+        """
+        Returns
+        -------
+        Returns the URI query string or an empty string if no query string was specified.
+        """
         return self.parts.query
 
     @property
     def fragment(self) -> str:
+        """
+        Returns
+        -------
+        Returns the fragment in this URI or the empty string if no fragment is specified.
+        """
         return self.parts.fragment
 
     @property
-    def username(self) -> str:
+    def username(self) -> Optional[str]:
+        """
+        Returns
+        -------
+        Returns the username in this URI if any, or None if there is no username specified.
+        """
         return self.parts.username
 
     @property
-    def password(self) -> str:
+    def password(self) -> Optional[str]:
+        """
+        Returns
+        -------
+        Returns the password specified in this URI or None if there is no password.
+        """
         return self.parts.password
 
     def __str__(self) -> str:
+        """Returns a string representation of this URL."""
         return self.parts.geturl()
 
 
 class StagingMode(Enum):
+    """
+    Defines the possible modes in which the staging of a file can be done.
+
+    JobExecutor implementations are not required to support all staging modes, but must default
+    to `COPY` if other modes are not implemented. Furthermore, modes different from `COPY` may only
+    make sense when staging is done locally.
+    """
+
     COPY = 1
+    """
+    Copies the file to be staged by performing an operation that is equivalent to the familiar
+    `cp` command.
+    """
     LINK = 2
+    """
+    Creates a symbolic link instead of copying the contents of files.
+    """
     MOVE = 3
+    """
+    Moves a file instead of copying it. Moving a file can be nearly instantaneous if both the
+    source and the destination are on the same filesystem. However, the OS will likely have to
+    resort to copying the contents of the file and the removing the source file if the source and
+    destination are on different filesystems, so it is unlikely for this mode to be beneficial over
+    a `COPY`.
+    """
 
 
 class StageOutFlags(Flag):
+    """
+    Specifies a set of flags that can be used to alter stage out behavior.
+
+    The flags can be combined using the bitwise or operator (`|`). For example,
+    `IF_PRESENT | ON_ERROR`. If none of the state conditions
+    (`ON_SUCCESS`, `ON_ERROR`, `ON_CANCEL`) are specified, it is assumed that the file should be
+    transferred in all cases, subject to the presence of the `IF_PRESENT` flag. That is,
+    `NONE` is equivalent to `ALWAYS` or `ON_SUCCESS | ON_ERROR | ON_CANCEL`, while
+    `IF_PRESENT` is equivalent to `IF_PRESENT | ALWAYS`.
+    """
+
+    NONE = 0
+    """
+    Indicates that no flags are set. This is equivalent to `ALWAYS`.
+    """
     IF_PRESENT = 1
+    """
+    Indicates that a file should only be transferred if it exists. If the file does not exist,
+    the stageout operation continues with the next file. If this flag is not set for a given file,
+    its absence will result in a stageout error which will cause the job to fail.
+    """
     ON_SUCCESS = 2
+    """
+    Indicates that a file should be transferred when the job succeeds (i.e., its exit code is zero).
+    If a job fails or is cancelled, and no other flags are set, the executor will not attempt to
+    stage out the file.
+    """
     ON_ERROR = 4
+    """
+    Indicates that a stageout should be performed if the job has failed (i.e., its exit code is
+    non-zero).
+    """
     ON_CANCEL = 8
+    """
+    Indicates that a file should be staged out if the job has been canceled.
+    """
     ALWAYS = ON_SUCCESS | ON_ERROR | ON_CANCEL
+    """
+    Indicates that a file should be staged out irrespective of the status of the job.
+    """
 
 
 class StageIn:
-    def __init__(self, source: Union[URI, str], target: Union[str, Path],
+    """A class representing a stagein directive."""
+
+    def __init__(self, source: Union[URI, Path, str], target: Union[str, Path],
                  mode: StagingMode = StagingMode.COPY) -> None:
+        """
+        Parameters
+        ----------
+        source
+            The source location of the stagein. If the source is a string or a :
+            class:`~pathlib.Path`, the location refers to a file on a filesystem accessible by the
+            process in which PSI/J is running. If the path is relative, it is interpreted to be
+            relative to the current working directory of the process in which PSI/J is running and
+            normalized to an absolute path. If the source is a :class:`.URI`, it may refer to a
+            remote location. Support for remote staging is not guaranteed and depends on the
+            implementation of the :class:`~psij.JobExecutor` that the job to which this stagein
+            directive belongs is submitted to.
+        target
+            The target location for the stagein, which can be either a string or a
+            :class:`~pathlib.Path`. If the path is relative, it is considered to be relative to the
+            job directory. That is, a job can access this file at the location specified by
+            `target` if it does not change its working directory from the one it starts in.
+        mode
+            A staging mode, which indicates how the staging is done. For details, see
+            :class:`.StagingMode`.
+        """
         if isinstance(source, str):
             source = URI(source)
+        if isinstance(source, Path):
+            source = URI(str(source))
         if isinstance(target, str):
             target = Path(target)
         self.source = source
         self.target = target
         self.mode = mode
 
+
+def _normalize_flags(flags: StageOutFlags) -> StageOutFlags:
+    if (flags & StageOutFlags.ALWAYS).value == 0:
+        return flags | StageOutFlags.ALWAYS
+    else:
+        return flags
+
+
 class StageOut:
-    def __init__(self, source: Union[str, Path], target: Union[str, URI],
+    """A class encapsulating a stageout directive."""
+
+    def __init__(self, source: Union[str, Path], target: Union[str, Path, URI],
                  flags: StageOutFlags = StageOutFlags.ALWAYS,
                  mode: StagingMode = StagingMode.COPY):
+        """
+        Parameters
+        ----------
+        source
+            The source location for the stagein, which can be either a string or a
+            :class:`~pathlib.Path`. If the path is relative, it is considered to be relative to the
+            job directory.
+        target
+            The target location of the stageout. If the target is a string or a
+            :class:`~pathlib.Path`, the location refers to a file on a filesystem accessible by the
+            process in which PSI/J is running. If the path is relative, it is interpreted to be
+            relative to the current working directory of the process in which PSI/J is running and
+            normalized to an absolute path. If the target is a :class:`.URI`, it may refer to a
+            remote location. Support for remote staging is not guaranteed and depends on the
+            implementation of the :class:`~psij.JobExecutor` that the job to which this stageout
+            directive belongs is submitted to.
+        flags
+            A set of flags specifying the conditions under which the stageout should occur. For
+            details, see :class:`.StageOutFlags`.
+        mode
+            A staging mode, which indicates how the staging is done. For details, see
+            :class:`.StagingMode`.
+        """
         if isinstance(source, str):
             source = Path(source)
         if isinstance(target, str):
             target = URI(target)
+        if isinstance(target, Path):
+            target = URI(str(target))
 
+        print(target.parts)
         self.source = source
         self.target = target
         self.flags = flags
         self.mode = mode
+
+    @property
+    def flags(self) -> StageOutFlags:
+        """
+        A set of flags specifying the conditions under which the stageout should occur.
+
+        For details, see :class:`.StageOutFlags`.
+        """
+        return self._flags
+
+    @flags.setter
+    def flags(self, flags: StageOutFlags) -> None:
+        self._flags = _normalize_flags(flags)

--- a/src/psij/staging.py
+++ b/src/psij/staging.py
@@ -1,0 +1,94 @@
+import urllib
+from enum import Enum, Flag
+from pathlib import Path
+from typing import Optional, Union
+
+
+class URI:
+    def __init__(self, urlstring: str) -> None:
+        self.parts = urllib.parse.urlparse(urlstring)
+
+    # a __getattr__ solution may be simpler, but doesn't play well with IDEs and
+    # is not quite self-documenting
+    @property
+    def hostname(self) -> Optional[str]:
+        return self.hostname
+
+    @property
+    def port(self) -> int:
+        return self.port
+
+    @property
+    def scheme(self) -> str:
+        return self.parts.scheme
+
+    @property
+    def netloc(self) -> str:
+        return self.parts.netloc
+
+    @property
+    def path(self) -> str:
+        return self.parts.path
+
+    @property
+    def params(self) -> str:
+        return self.parts.params
+
+    @property
+    def query(self) -> str:
+        return self.parts.query
+
+    @property
+    def fragment(self) -> str:
+        return self.parts.fragment
+
+    @property
+    def username(self) -> str:
+        return self.parts.username
+
+    @property
+    def password(self) -> str:
+        return self.parts.password
+
+    def __str__(self) -> str:
+        return self.parts.geturl()
+
+
+class StagingMode(Enum):
+    COPY = 1
+    LINK = 2
+    MOVE = 3
+
+
+class StageOutFlags(Flag):
+    IF_PRESENT = 1
+    ON_SUCCESS = 2
+    ON_ERROR = 4
+    ON_CANCEL = 8
+    ALWAYS = ON_SUCCESS | ON_ERROR | ON_CANCEL
+
+
+class StageIn:
+    def __init__(self, source: Union[URI, str], target: Union[str, Path],
+                 mode: StagingMode = StagingMode.COPY) -> None:
+        if isinstance(source, str):
+            source = URI(source)
+        if isinstance(target, str):
+            target = Path(target)
+        self.source = source
+        self.target = target
+        self.mode = mode
+
+class StageOut:
+    def __init__(self, source: Union[str, Path], target: Union[str, URI],
+                 flags: StageOutFlags = StageOutFlags.ALWAYS,
+                 mode: StagingMode = StagingMode.COPY):
+        if isinstance(source, str):
+            source = Path(source)
+        if isinstance(target, str):
+            target = URI(target)
+
+        self.source = source
+        self.target = target
+        self.flags = flags
+        self.mode = mode

--- a/src/psij/utils.py
+++ b/src/psij/utils.py
@@ -1,6 +1,20 @@
+import atexit
+import io
+import logging
 import os
+import random
+import socket
+import tempfile
 import threading
-from typing import Type, Dict, Optional
+import time
+from pathlib import Path
+from typing import Type, Dict, Optional, Tuple, Set, List
+
+import psutil
+
+from psij import JobExecutor, Job, JobState, JobStatus
+
+logger = logging.getLogger(__name__)
 
 
 class SingletonThread(threading.Thread):
@@ -16,7 +30,7 @@ class SingletonThread(threading.Thread):
     the `run` method.
     """
 
-    _instances: Dict[int, 'SingletonThread'] = {}
+    _instances: Dict[int, Dict[type, 'SingletonThread']] = {}
     _lock = threading.RLock()
 
     def __init__(self, name: Optional[str] = None, daemon: bool = False) -> None:
@@ -42,8 +56,142 @@ class SingletonThread(threading.Thread):
         """
         with cls._lock:
             my_pid = os.getpid()
-            if my_pid not in cls._instances:
+            if my_pid in cls._instances:
+                classes = cls._instances[my_pid]
+            else:
+                classes = {}
+                cls._instances[my_pid] = classes
+            if cls in classes:
+                return classes[cls]
+            else:
                 instance = cls()
-                cls._instances[my_pid] = instance
+                classes[cls] = instance
                 instance.start()
-            return cls._instances[my_pid]
+                return instance
+
+
+class _StatusUpdater(SingletonThread):
+    # we are expecting short messages in the form <jobid> <status>
+    RECV_BUFSZ = 2048
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = 'Status Update Thread'
+        self.daemon = True
+        self.work_directory = Path.home() / '.psij'
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.socket.setblocking(True)
+        self.socket.settimeout(0.5)
+        self.socket.bind(('', 0))
+        self.update_port = self.socket.getsockname()[1]
+        self.ips = self._get_ips()
+        logger.debug('Local IPs: %s' % self.ips)
+        logger.debug('Status updater port: %s' % self.update_port)
+        self._create_update_file()
+        logger.debug('Update file: %s' % self.update_file.name)
+        self.partial_file_data = ''
+        self.partial_net_data = ''
+        self._jobs: Dict[str, Tuple[Job, JobExecutor]] = {}
+        self._jobs_lock = threading.RLock()
+        self._sync_ids: Set[str] = set()
+        self._last_received = ''
+
+    def _get_ips(self) -> List[str]:
+        addrs = psutil.net_if_addrs()
+        r = []
+        for name, l in addrs.items():
+            if name == 'lo':
+                continue
+            for a in l:
+                if a.family == socket.AddressFamily.AF_INET:
+                    r.append(a.address)
+        return r
+
+    def _create_update_file(self) -> None:
+        f = tempfile.NamedTemporaryFile(dir=self.work_directory, prefix='supd_', delete=False)
+        name = f.name
+        self.update_file_name = name
+        atexit.register(os.remove, name)
+        f.close()
+        self.update_file = open(name, 'r+b')
+        self.update_file.seek(0, io.SEEK_END)
+        self.update_file_pos = self.update_file.tell()
+
+    def register_job(self, job: Job, ex: JobExecutor) -> None:
+        with self._jobs_lock:
+            self._jobs[job.id] = (job, ex)
+
+    def unregister_job(self, job: Job) -> None:
+        with self._jobs_lock:
+            try:
+                del self._jobs[job.id]
+            except KeyError:
+                # There are cases when it's difficult to esnure that this method is only called
+                # once for each job. Instead, ignore errors here, since the ultimate goal is to
+                # remove the job from the _jobs dictionary.
+                pass
+
+    def step(self) -> None:
+        self.update_file.seek(0, io.SEEK_END)
+        pos = self.update_file.tell()
+        if pos > self.update_file_pos:
+            self.update_file.seek(self.update_file_pos, io.SEEK_SET)
+            n = pos - self.update_file_pos
+            self._process_update_data(self.update_file.read(n))
+            self.update_file_pos = pos
+        else:
+            try:
+                data = self.socket.recv(_StatusUpdater.RECV_BUFSZ)
+                self._process_update_data(data)
+            except TimeoutError:
+                pass
+            except BlockingIOError:
+                pass
+
+    def run(self) -> None:
+        while True:
+            self.step()
+
+    def flush(self) -> None:
+        # Ensures that, upon return from this call, all updates available before this call have
+        # been processed. To do so, we send a UDP packet to the socket to wake it up and wait until
+        # it is received. This does not guarantee that file-based updates are necessarily
+        # processes, since that depends on many factors.
+        token = '_SYNC ' + str(random.getrandbits(128))
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.sendto(bytes(token, 'utf-8'), ('127.0.0.1', self.update_port))
+        delay = 0.0001
+        while token not in self._sync_ids:
+            time.sleep(delay)
+            delay *= 2
+
+    def _process_update_data(self, data: bytes) -> None:
+        sdata = data.decode('utf-8')
+        if sdata == self._last_received:
+            # we send UDP packets to all IP addresses of the submit host, which may
+            # result in duplicates, so we drop consecutive messages that are identical
+            return
+        else:
+            self._last_received = sdata
+        lines = sdata.splitlines()
+        for line in lines:
+            if sdata.startswith('_SYNC '):
+                self._sync_ids.add(sdata)
+                continue
+            els = line.split()
+            if len(els) > 2 and els[1] == 'LOG':
+                logger.info('%s %s' % (els[0], ' '.join(els[2:])))
+                continue
+            if len(els) != 2:
+                logger.warning('Invalid status update message received: %s' % line)
+                continue
+            job_id = els[0]
+            state = JobState.from_name(els[1])
+            job = None
+            with self._jobs_lock:
+                try:
+                    (job, executor) = self._jobs[job_id]
+                except KeyError:
+                    logger.debug('Received status updated for inexistent job with id %s' % job_id)
+            if job:
+                executor._set_job_status(job, JobStatus(state))

--- a/tests/_test_tools.py
+++ b/tests/_test_tools.py
@@ -4,7 +4,7 @@ import tempfile
 from contextlib import contextmanager
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional, Union, Iterator
+from typing import Optional, Union, Iterator, IO
 
 from executor_test_params import ExecutorTestParams
 
@@ -37,8 +37,14 @@ def assert_completed(job: Job, status: Optional[JobStatus], attached: bool = Fal
     if status.state != JobState.COMPLETED:
         if not attached:
             assert job.spec is not None
-            stdout = _read_file(job.spec.stdout_path)
-            stderr = _read_file(job.spec.stderr_path)
+            try:
+                stdout = _read_file(job.spec.stdout_path)
+            except Exception:
+                stdout = '<not found>'
+            try:
+                stderr = _read_file(job.spec.stderr_path)
+            except Exception:
+                stderr = '<not found>'
             raise AssertionError('Job not completed. Exit code: %s, Status message: %s, '
                                  'stdout: %s, stderr: %s'
                                  % (status.exit_code, status.message, stdout, stderr))
@@ -72,3 +78,59 @@ def _deploy(path: Union[Path, str]) -> Iterator[Path]:
             yield Path(df.name)
         finally:
             os.unlink(df.name)
+
+
+@contextmanager
+def _tempfile() -> Iterator[IO[str]]:
+    # we have type: ignore above because mypy complains that _TemporaryFileWrapper is generic,
+    # but adding [str] to it results in a runtime error stating that _TemporaryFileWrapper is
+    # not subscriptable
+    _make_test_dir()
+    test_dir = Path.home() / '.psij' / 'test'
+    with tempfile.NamedTemporaryFile(mode='w', dir=test_dir, delete=False) as f:
+        try:
+            yield f
+        finally:
+            try:
+                os.unlink(f.name)
+            except FileNotFoundError:
+                # some tests may remove the file themselves
+                pass
+
+
+@contextmanager
+def _temppath() -> Iterator[Path]:
+    _make_test_dir()
+    test_dir = Path.home() / '.psij' / 'test'
+    with tempfile.NamedTemporaryFile(mode='w', dir=test_dir, delete=False) as f:
+        try:
+            f.close()
+            yield Path(f.name)
+        finally:
+            try:
+                os.unlink(f.name)
+            except FileNotFoundError:
+                # some tests may remove the file themselves
+                pass
+
+
+@contextmanager
+def _tempdir(keep: bool = False) -> Iterator[Path]:
+    _make_test_dir()
+    d = tempfile.mkdtemp(dir=Path.cwd())
+    try:
+        yield Path(d)
+        shutil.rmtree(d)
+    except Exception:
+        if not keep:
+            shutil.rmtree(d)
+        raise
+
+
+def _write_file(f: Union[Path, IO[str]], contents: str) -> None:
+    if isinstance(f, Path):
+        f = f.open('w')
+    try:
+        f.write(contents)
+    finally:
+        f.close()

--- a/tests/plugins1/_batch_test/test/test.mustache
+++ b/tests/plugins1/_batch_test/test/test.mustache
@@ -44,26 +44,16 @@ done
 
 export PSIJ_NODEFILE
 
-update_status STAGEIN
-{{#stagein_set}}
-    do_stagein "{{source}}" "{{target}}" {{mode}}
-{{/stagein_set}}
-
+{{> stagein}}
 update_status ACTIVE
+
 {{#job.spec.inherit_environment}}env \{{/job.spec.inherit_environment}}{{^job.spec.inherit_environment}}env --ignore-environment \{{/job.spec.inherit_environment}}{{#env}}
 {{name}}="{{value}}" \{{/env}}
 {{#psij.launch_command}}{{.}} {{/psij.launch_command}}
-_EC="$?"
+_PSIJ_JOB_EC="$?"
 
-update_status STAGEOUT
-{{#stageout_set}}
-    do_stageout "{{source}}" "{{target}}" {{mode}} {{flags}} $_EC
-{{/stageout_set}}
+{{> stageout}}
+{{> cleanup}}
 
-update_status CLEANUP
-{{#cleanup_set}}
-    do_cleanup {{.}}
-{{/cleanup_set}}
 
-echo "$_EC" > "{{psij.script_dir}}/$PSIJ_BATCH_TEST_JOB_ID.ec"
->>>>>>> 554b43e (Initial staging commit)
+echo $_PSIJ_JOB_EC > "{{psij.script_dir}}/$PSIJ_BATCH_TEST_JOB_ID.ec"

--- a/tests/plugins1/_batch_test/test/test.mustache
+++ b/tests/plugins1/_batch_test/test/test.mustache
@@ -2,6 +2,8 @@
 
 exec &> "{{psij.script_dir}}/$PSIJ_BATCH_TEST_JOB_ID.out"
 
+{{> batch_lib}}
+
 {{#job.spec.directory}}
 cd "{{.}}"
 {{/job.spec.directory}}
@@ -42,8 +44,26 @@ done
 
 export PSIJ_NODEFILE
 
+update_status STAGEIN
+{{#stagein_set}}
+    do_stagein "{{source}}" "{{target}}" {{mode}}
+{{/stagein_set}}
+
+update_status ACTIVE
 {{#job.spec.inherit_environment}}env \{{/job.spec.inherit_environment}}{{^job.spec.inherit_environment}}env --ignore-environment \{{/job.spec.inherit_environment}}{{#env}}
 {{name}}="{{value}}" \{{/env}}
 {{#psij.launch_command}}{{.}} {{/psij.launch_command}}
+_EC="$?"
 
-echo "$?" > "{{psij.script_dir}}/$PSIJ_BATCH_TEST_JOB_ID.ec"
+update_status STAGEOUT
+{{#stageout_set}}
+    do_stageout "{{source}}" "{{target}}" {{mode}} {{flags}} $_EC
+{{/stageout_set}}
+
+update_status CLEANUP
+{{#cleanup_set}}
+    do_cleanup {{.}}
+{{/cleanup_set}}
+
+echo "$_EC" > "{{psij.script_dir}}/$PSIJ_BATCH_TEST_JOB_ID.ec"
+>>>>>>> 554b43e (Initial staging commit)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -29,9 +29,12 @@ class TestCallbacks(TestCase):
         jex.submit(job)
         job.wait()
 
-        self.assertEqual(len(self._cb_states), 3)
+        self.assertEqual(len(self._cb_states), 6)
         self.assertIn(psij.JobState.QUEUED, self._cb_states)
+        self.assertIn(psij.JobState.STAGE_IN, self._cb_states)
         self.assertIn(psij.JobState.ACTIVE, self._cb_states)
+        self.assertIn(psij.JobState.STAGE_OUT, self._cb_states)
+        self.assertIn(psij.JobState.CLEANUP, self._cb_states)
         self.assertIn(psij.JobState.FAILED, self._cb_states)
 
         self._cb_states = list()
@@ -41,9 +44,12 @@ class TestCallbacks(TestCase):
         jex.submit(job)
         job.wait()
 
-        self.assertEqual(len(self._cb_states), 3)
+        self.assertEqual(len(self._cb_states), 6)
         self.assertIn(psij.JobState.QUEUED, self._cb_states)
+        self.assertIn(psij.JobState.STAGE_IN, self._cb_states)
         self.assertIn(psij.JobState.ACTIVE, self._cb_states)
+        self.assertIn(psij.JobState.STAGE_OUT, self._cb_states)
+        self.assertIn(psij.JobState.CLEANUP, self._cb_states)
         self.assertIn(psij.JobState.COMPLETED, self._cb_states)
 
     def test_job_executor_callbacks(self) -> None:
@@ -55,7 +61,10 @@ class TestCallbacks(TestCase):
         jex.submit(job)
         job.wait()
 
-        self.assertEqual(len(self._cb_states), 3)
+        self.assertEqual(len(self._cb_states), 6)
         self.assertIn(psij.JobState.QUEUED, self._cb_states)
+        self.assertIn(psij.JobState.STAGE_IN, self._cb_states)
         self.assertIn(psij.JobState.ACTIVE, self._cb_states)
+        self.assertIn(psij.JobState.STAGE_OUT, self._cb_states)
+        self.assertIn(psij.JobState.CLEANUP, self._cb_states)
         self.assertIn(psij.JobState.COMPLETED, self._cb_states)

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,25 +1,227 @@
-from tempfile import NamedTemporaryFile
+from pathlib import Path
 
 from executor_test_params import ExecutorTestParams
-from _test_tools import _get_executor_instance, _get_timeout, assert_completed, _make_test_dir
-from psij import Job, JobSpec
+from _test_tools import _get_executor_instance, _get_timeout, assert_completed, _tempfile, \
+    _temppath, _tempdir, _write_file, _read_file
+from psij import Job, JobSpec, JobState
+from psij.staging import StageIn, StageOut, StagingMode, StageOutFlags
+import pytest
 
 
-def test_stagein(execparams: ExecutorTestParams) -> None:
-    with NamedTemporaryFile(delete=False) as outf:
-        outf.close()
-        with NamedTemporaryFile(mode='w', delete=False) as f:
+@pytest.mark.parametrize('mode', [StagingMode.COPY, StagingMode.MOVE, StagingMode.LINK])
+def test_stagein(execparams: ExecutorTestParams, mode: StagingMode) -> None:
+    if execparams.executor != 'local' and execparams.launcher != 'single':
+        # The launcher should not affect the staging, so we test all launchers locally,
+        # but for the other executors, we only test with the single launcher
+        pytest.skip()
+    # The executors are not mandated to implement the staging modes, but they are
+    # meant to default to COPY if MOVE and LINK are not implemented, so we test
+    # that things function correctly, but not how that is done
+    with _temppath() as out_path, _temppath() as err_path, _tempdir() as dir:
+        with _tempfile() as f1, _tempfile() as f2:
+            _write_file(f1, 'ABCD')
+            _write_file(f2, 'EFGH')
 
-            f.write('ABCD')
-            f.close()
-
-            job = Job(JobSpec(executable='/bin/cat', stdout_path=outf.name,
+            job = Job(JobSpec('/bin/cat', ['in1.txt', 'subdir/in2.txt'],
+                              directory=dir, stdout_path=out_path, stderr_path=err_path,
                               launcher=execparams.launcher))
+            assert job.spec is not None
+            job.spec.stage_in = {
+                StageIn(f1.name, 'in1.txt', mode=mode),
+                StageIn(f2.name, 'subdir/in2.txt', mode=mode),
+            }
             ex = _get_executor_instance(execparams, job)
             ex.submit(job)
             status = job.wait(timeout=_get_timeout(execparams))
             assert_completed(job, status)
 
-            with open(outf, 'r') as out:
-                result = out.read()
-            assert result.strip() == 'ABCD'
+            assert _read_file(out_path) == 'ABCDEFGH'
+
+
+@pytest.mark.parametrize('mode', [StagingMode.COPY, StagingMode.MOVE, StagingMode.LINK])
+def test_dir_stagein(execparams: ExecutorTestParams, mode: StagingMode) -> None:
+    if execparams.executor != 'local' and execparams.launcher != 'single':
+        pytest.skip()
+    # The executors are not mandated to implement the staging modes, but they are
+    # meant to default to COPY if MOVE and LINK are not implemented, so we test
+    # that things function correctly, but not how that is done
+    with _temppath() as out_path, _temppath() as err_path, _tempdir() as dir:
+        with _tempdir() as in_dir:
+            sub_dir = in_dir / 'subdir'
+            sub_dir.mkdir()
+            f1 = sub_dir / 'in3.txt'
+            f2 = sub_dir / 'in4.txt'
+            _write_file(f1, 'IJKL')
+            _write_file(f2, 'MNOP')
+
+            job = Job(JobSpec('/bin/cat', ['indir/in3.txt', 'indir/in4.txt'],
+                              directory=dir, stdout_path=out_path, stderr_path=err_path,
+                              launcher=execparams.launcher))
+            assert job.spec is not None
+            job.spec.stage_in = {
+                StageIn(sub_dir, 'indir', mode=mode),
+            }
+            ex = _get_executor_instance(execparams, job)
+            ex.submit(job)
+            status = job.wait(timeout=_get_timeout(execparams))
+            assert_completed(job, status)
+
+            assert _read_file(out_path) == 'IJKLMNOP'
+
+
+@pytest.mark.parametrize('mode', [StagingMode.COPY, StagingMode.MOVE, StagingMode.LINK])
+def test_stageout(execparams: ExecutorTestParams, mode: StagingMode) -> None:
+    if execparams.executor != 'local' and execparams.launcher != 'single':
+        pytest.skip()
+    with _temppath() as out_path, _temppath() as err_path, _tempdir() as dir:
+        job = Job(JobSpec('/bin/echo', ['-n', 'CDEF'], directory=dir,
+                          stdout_path='out.txt', stderr_path=err_path,
+                          launcher=execparams.launcher))
+        assert job.spec is not None
+        job.spec.stage_out = {
+            StageOut('out.txt', out_path, mode=mode)
+        }
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert_completed(job, status)
+
+        assert _read_file(out_path) == 'CDEF'
+
+
+def test_stageout_flags1(execparams: ExecutorTestParams) -> None:
+    if execparams.executor != 'local' and execparams.launcher != 'single':
+        pytest.skip()
+    with (_temppath() as out1_path, _temppath() as out2_path, _temppath() as err_path,
+          _tempdir() as dir):
+
+        out2_path.unlink()
+        job = Job(JobSpec('/bin/echo', ['-n', 'ABC123'],
+                          directory=dir, stdout_path='out1.txt', stderr_path=err_path,
+                          launcher=execparams.launcher))
+        assert job.spec is not None
+        job.spec.stage_out = {
+            StageOut('out1.txt', out1_path, flags=StageOutFlags.IF_PRESENT),
+            StageOut('out2.txt', out2_path, flags=StageOutFlags.IF_PRESENT)
+        }
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert_completed(job, status)
+
+        assert _read_file(out1_path) == 'ABC123'
+        assert not out2_path.exists()
+
+
+def test_stageout_flags2(execparams: ExecutorTestParams) -> None:
+    if execparams.executor != 'local' and execparams.launcher != 'single':
+        pytest.skip()
+    with _temppath() as out_path, _temppath() as err_path, _tempdir() as dir:
+        job = Job(JobSpec('/bin/echo', ['-n', 'EFG456'],
+                          directory=dir, stdout_path='out.txt', stderr_path=err_path,
+                          launcher=execparams.launcher))
+        assert job.spec is not None
+        job.spec.stage_out = {
+            StageOut('out.txt', out_path, flags=StageOutFlags.ON_SUCCESS),
+        }
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert_completed(job, status)
+
+        assert _read_file(out_path) == 'EFG456'
+
+    with _temppath() as out_path, _temppath() as err_path, _tempdir() as dir:
+        out_path.unlink()
+        job = Job(JobSpec('/bin/bash', ['-c', 'echo -n "ABC" > out.txt; exit 1'],
+                          directory=dir, stderr_path=err_path,
+                          launcher=execparams.launcher))
+        assert job.spec is not None
+        job.spec.stage_out = {
+            StageOut('out.txt', out_path, flags=StageOutFlags.ON_SUCCESS),
+        }
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert status
+        assert status.state == JobState.FAILED
+        assert not out_path.exists()
+
+
+def test_stageout_flags3(execparams: ExecutorTestParams) -> None:
+    if execparams.executor != 'local' and execparams.launcher != 'single':
+        pytest.skip()
+    with _temppath() as out_path, _temppath() as err_path, _tempdir() as dir:
+        out_path.unlink()
+        job = Job(JobSpec('/bin/echo', ['-n', 'EFG456'],
+                          directory=dir, stdout_path='out.txt', stderr_path=err_path,
+                          launcher=execparams.launcher))
+        assert job.spec is not None
+        job.spec.stage_out = {
+            StageOut('out.txt', out_path, flags=StageOutFlags.ON_ERROR),
+        }
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert_completed(job, status)
+
+        assert not out_path.exists()
+
+    with _temppath() as out_path, _temppath() as err_path, _tempdir() as dir:
+        job = Job(JobSpec('/bin/bash', ['-c', 'echo -n "ABC" > out.txt; exit 1'],
+                          directory=dir, stderr_path=err_path,
+                          launcher=execparams.launcher))
+        assert job.spec is not None
+        job.spec.stage_out = {
+            StageOut('out.txt', out_path, flags=StageOutFlags.ON_ERROR),
+        }
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert status
+        assert status.state == JobState.FAILED
+        assert out_path.exists()
+        assert _read_file(out_path) == 'ABC'
+
+
+def test_cleanup(execparams: ExecutorTestParams) -> None:
+    if execparams.executor != 'local' and execparams.launcher != 'single':
+        pytest.skip()
+    with _temppath() as out_path, _temppath() as err_path, _tempdir() as dir:
+        job = Job(JobSpec('/bin/echo', ['-n', 'ABC'],
+                          directory=dir, stdout_path='out.txt', stderr_path=err_path,
+                          launcher=execparams.launcher))
+        assert job.spec is not None
+        job.spec.stage_out = {
+            StageOut('out.txt', out_path, flags=StageOutFlags.IF_PRESENT),
+        }
+        job.spec.cleanup = {Path('out.txt')}
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert_completed(job, status)
+        assert out_path.exists()
+        assert not (dir / 'out.txt').exists()
+        assert _read_file(out_path) == 'ABC'
+
+
+def test_cleanup2(execparams: ExecutorTestParams) -> None:
+    if execparams.executor != 'local' and execparams.launcher != 'single':
+        pytest.skip()
+    with _temppath() as out_path, _temppath() as err_path, _tempdir() as dir:
+        job = Job(JobSpec('/bin/bash', ['-c', 'echo -n "ABC" > out.txt; exit 1'],
+                          directory=dir, stderr_path=err_path,
+                          launcher=execparams.launcher))
+        assert job.spec is not None
+        job.spec.stage_out = {
+            StageOut('out.txt', out_path, flags=StageOutFlags.IF_PRESENT),
+        }
+        job.spec.cleanup = {Path('out.txt')}
+        job.spec.cleanup_on_failure = False
+        ex = _get_executor_instance(execparams, job)
+        ex.submit(job)
+        status = job.wait(timeout=_get_timeout(execparams))
+        assert status is not None
+        assert status.state == JobState.FAILED
+        assert (dir / 'out.txt').exists()
+        assert _read_file(out_path) == 'ABC'

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,0 +1,25 @@
+from tempfile import NamedTemporaryFile
+
+from executor_test_params import ExecutorTestParams
+from _test_tools import _get_executor_instance, _get_timeout, assert_completed, _make_test_dir
+from psij import Job, JobSpec
+
+
+def test_stagein(execparams: ExecutorTestParams) -> None:
+    with NamedTemporaryFile(delete=False) as outf:
+        outf.close()
+        with NamedTemporaryFile(mode='w', delete=False) as f:
+
+            f.write('ABCD')
+            f.close()
+
+            job = Job(JobSpec(executable='/bin/cat', stdout_path=outf.name,
+                              launcher=execparams.launcher))
+            ex = _get_executor_instance(execparams, job)
+            ex.submit(job)
+            status = job.wait(timeout=_get_timeout(execparams))
+            assert_completed(job, status)
+
+            with open(outf, 'r') as out:
+                result = out.read()
+            assert result.strip() == 'ABCD'


### PR DESCRIPTION
This PR adds file staging to some executors (local and the batch family).

- It does so mostly through templates.
- It addresses the status updates issues mentioned in https://github.com/ExaWorks/job-api-spec/pull/164 using a UDP service that simple netcat commands (and we have to carefully test there because there might be multiple versions of that tool) can send from the batch script. As a backup (if not netcat can be found), a file is used.
- Solves the issue of the state order inversion vs. when-is-the-native-id-available in the local executor by making the local executor template based (like the batch scheduler ones) and implementing staging as it is done in the batch scheduler executors. This has the disadvantage that it only delays finding a better solution for the native_id/order issue that will inevitably happen with synthetic-staging executors, but the plus is that the local executor is closer, for testing purposes, to the batch scheduler ones.
- Adds some testing tools for managing temporary files/directories
- Ensures that polling threads for batch scheduler executors are shut down when the executor is GC-ed