### PR TITLE
Checking existence and then deleting is not atomic, so try to delete and

### DIFF
--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -541,8 +541,12 @@ class BatchSchedulerExecutor(JobExecutor):
             assert isinstance(self.config, BatchSchedulerExecutorConfig)
             if not self.config.keep_files:
                 submit_file_path = self.work_directory / (job.id + '.job')
-                if submit_file_path.exists():
+                try:
                     submit_file_path.unlink()
+                except FileNotFoundError:
+                    # this can reasonably happen for attached jobs when the main
+                    # job cleans up the script instead
+                    pass
         except Exception as ex:
             logger.warning('Job %s: failed clean submit script: %s', job.id, ex)
 

--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -612,7 +612,10 @@ class BatchSchedulerExecutor(JobExecutor):
             assert suffix
             path = self.work_directory / (job.native_id + suffix)
         if force or path.exists():
-            path.unlink()
+            try:
+                path.unlink()
+            except FileNotFonudError:
+                pass  # see above; attached job may race with original job
 
     def list(self) -> List[str]:
         """Returns a list of jobs known to the underlying implementation.

--- a/src/psij/executors/batch/batch_scheduler_executor.py
+++ b/src/psij/executors/batch/batch_scheduler_executor.py
@@ -614,7 +614,7 @@ class BatchSchedulerExecutor(JobExecutor):
         if force or path.exists():
             try:
                 path.unlink()
-            except FileNotFonudError:
+            except FileNotFoundError:
                 pass  # see above; attached job may race with original job
 
     def list(self) -> List[str]:


### PR DESCRIPTION
ignore FileNotFoundError instead

See test_executor::test_attach2[slurm:srun on [https://testing.psij.io/run.html?...](https://testing.psij.io/run.html?site_id=perlmutter.nersc.gov&run_id=2024022406-3ac2618e18df98e9eedf6f962587213e5f3e24a41076615c4973d544da9972ea#branch-main) for the failure.