### PR TITLE
Use packaging.versions insted of distutil.version, since the latter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ venv*
 build/
 docs/.web-build
 web-build/
+.packages/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,8 @@ python_use_unqualified_type_names = True
 autodoc_mock_imports = ['flux']
 nitpick_ignore = [
     ('py:class', 'distutils.version.StrictVersion'),
-    ('py:class', 'distutils.version.Version')
+    ('py:class', 'distutils.version.Version'),
+    ('py:class', 'packaging.version.Version')
 ]
 
 if web_docs:

--- a/docs/development/tutorial_add_executor.rst
+++ b/docs/development/tutorial_add_executor.rst
@@ -68,11 +68,11 @@ Create a simple BatchSchedulerExecutor subclass that does nothing new in `psijpb
 
 and create a descriptor file to tell PSI/J about this, ``psij-descriptors/pbspro.py``::
 
-  from distutils.version import StrictVersion
+  from packaging.version import Version
 
   from psij._descriptor import _Descriptor
 
-  __PSI_J_EXECUTORS__ = [_Descriptor(name='pbspro', version=StrictVersion('0.0.1'),
+  __PSI_J_EXECUTORS__ = [_Descriptor(name='pbspro', version=Version('0.0.1'),
                                      cls='psijpbs.pbspro.PBSProJobExecutor')]
 
 Now, run the test suite. It should fail with an error reporting that the resource manager specific methods of BatchSchedulerExecutor have not been implemented::

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ psutil~=5.9
 pystache>=0.6.0
 typeguard~=2.12
 typing-compat
+packaging~=24.0

--- a/src/psij-descriptors/aprun_descriptor.py
+++ b/src/psij-descriptors/aprun_descriptor.py
@@ -1,8 +1,7 @@
-from distutils.version import StrictVersion
-
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 __PSI_J_LAUNCHERS__ = [
-    Descriptor(name='aprun', version=StrictVersion('0.0.1'),
+    Descriptor(name='aprun', version=Version('0.0.1'),
                cls='psij.launchers.aprun.AprunLauncher'),
 ]

--- a/src/psij-descriptors/cobalt_descriptor.py
+++ b/src/psij-descriptors/cobalt_descriptor.py
@@ -1,7 +1,6 @@
-from distutils.version import StrictVersion
-
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 
-__PSI_J_EXECUTORS__ = [Descriptor(name="cobalt", nice_name='Cobalt', version=StrictVersion("0.0.1"),
+__PSI_J_EXECUTORS__ = [Descriptor(name="cobalt", nice_name='Cobalt', version=Version("0.0.1"),
                                   cls='psij.executors.batch.cobalt.CobaltJobExecutor')]

--- a/src/psij-descriptors/core_descriptors.py
+++ b/src/psij-descriptors/core_descriptors.py
@@ -1,16 +1,16 @@
-from distutils.version import StrictVersion
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 __PSI_J_EXECUTORS__ = [
-    Descriptor(name='local', nice_name='Local', version=StrictVersion('0.0.1'),
+    Descriptor(name='local', nice_name='Local', version=Version('0.0.1'),
                cls='psij.executors.local.LocalJobExecutor')
 ]
 
 __PSI_J_LAUNCHERS__ = [
-    Descriptor(name='single', version=StrictVersion('0.0.1'),
+    Descriptor(name='single', version=Version('0.0.1'),
                cls='psij.launchers.single.SingleLauncher'),
-    Descriptor(name='multiple', version=StrictVersion('0.0.1'),
+    Descriptor(name='multiple', version=Version('0.0.1'),
                cls='psij.launchers.multiple.MultipleLauncher'),
-    Descriptor(name='mpirun', version=StrictVersion('0.0.1'),
+    Descriptor(name='mpirun', version=Version('0.0.1'),
                cls='psij.launchers.mpirun.MPILauncher'),
 ]

--- a/src/psij-descriptors/flux_descriptor.py
+++ b/src/psij-descriptors/flux_descriptor.py
@@ -1,7 +1,6 @@
-from distutils.version import StrictVersion
-
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 
-__PSI_J_EXECUTORS__ = [Descriptor(name='flux', nice_name='Flux', version=StrictVersion('0.0.1'),
+__PSI_J_EXECUTORS__ = [Descriptor(name='flux', nice_name='Flux', version=Version('0.0.1'),
                                   cls='psij.executors.flux.FluxJobExecutor')]

--- a/src/psij-descriptors/jsrun_descriptor.py
+++ b/src/psij-descriptors/jsrun_descriptor.py
@@ -1,8 +1,7 @@
-from distutils.version import StrictVersion
-
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 __PSI_J_LAUNCHERS__ = [
-    Descriptor(name='jrun', version=StrictVersion('0.0.1'),
+    Descriptor(name='jrun', version=Version('0.0.1'),
                cls='psij.launchers.jsrun.JsrunLauncher'),
 ]

--- a/src/psij-descriptors/lsf_descriptor.py
+++ b/src/psij-descriptors/lsf_descriptor.py
@@ -1,7 +1,6 @@
-from distutils.version import StrictVersion
-
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 
-__PSI_J_EXECUTORS__ = [Descriptor(name='lsf', nice_name='LSF', version=StrictVersion('0.0.1'),
+__PSI_J_EXECUTORS__ = [Descriptor(name='lsf', nice_name='LSF', version=Version('0.0.1'),
                                   cls='psij.executors.batch.lsf.LsfJobExecutor')]

--- a/src/psij-descriptors/pbs_descriptor.py
+++ b/src/psij-descriptors/pbs_descriptor.py
@@ -1,11 +1,10 @@
-from distutils.version import StrictVersion
-
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 
 __PSI_J_EXECUTORS__ = [Descriptor(name='pbs', nice_name='PBS Pro', aliases=['pbspro'],
-                                  version=StrictVersion('0.0.2'),
+                                  version=Version('0.0.2'),
                                   cls='psij.executors.batch.pbs.PBSJobExecutor'),
                        Descriptor(name='pbs_classic', nice_name='PBS Classic', aliases=['torque'],
-                                  version=StrictVersion('0.0.2'),
+                                  version=Version('0.0.2'),
                                   cls='psij.executors.batch.pbs_classic.PBSClassicJobExecutor')]

--- a/src/psij-descriptors/rp_descriptor.py
+++ b/src/psij-descriptors/rp_descriptor.py
@@ -1,8 +1,7 @@
-from distutils.version import StrictVersion
-
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 
 __PSI_J_EXECUTORS__ = [Descriptor(name='rp', nice_name='Radical Pilot',
-                                  version=StrictVersion('0.0.1'),
+                                  version=Version('0.0.1'),
                                   cls='psij.executors.rp.RPJobExecutor')]

--- a/src/psij-descriptors/slurm_descriptor.py
+++ b/src/psij-descriptors/slurm_descriptor.py
@@ -1,7 +1,6 @@
-from distutils.version import StrictVersion
-
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 
-__PSI_J_EXECUTORS__ = [Descriptor(name='slurm', nice_name='Slurm', version=StrictVersion('0.0.1'),
+__PSI_J_EXECUTORS__ = [Descriptor(name='slurm', nice_name='Slurm', version=Version('0.0.1'),
                                   cls='psij.executors.batch.slurm.SlurmJobExecutor')]

--- a/src/psij-descriptors/srun_descriptor.py
+++ b/src/psij-descriptors/srun_descriptor.py
@@ -1,8 +1,7 @@
-from distutils.version import StrictVersion
-
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 __PSI_J_LAUNCHERS__ = [
-    Descriptor(name='srun', version=StrictVersion('0.0.1'),
+    Descriptor(name='srun', version=Version('0.0.1'),
                cls='psij.launchers.srun.SrunLauncher'),
 ]

--- a/src/psij/_plugins.py
+++ b/src/psij/_plugins.py
@@ -1,7 +1,7 @@
 import importlib
 import logging
 from bisect import bisect_left
-from distutils.versionpredicate import VersionPredicate
+from packaging.specifiers import SpecifierSet
 from types import ModuleType
 from typing import Tuple, Dict, List, Union, Type, Any, Optional, TypeVar
 
@@ -116,9 +116,9 @@ def _get_plugin_class(name: str, version_constraint: Optional[str], type: str,
     versions = store[name]
     selected = None
     if version_constraint:
-        pred = VersionPredicate('x(' + version_constraint + ')')
+        pred = SpecifierSet(version_constraint)
         for entry in reversed(versions):
-            if pred.satisfied_by(entry.version):
+            if entry.version in pred:
                 selected = entry
     else:
         selected = versions[-1]

--- a/src/psij/descriptor.py
+++ b/src/psij/descriptor.py
@@ -68,17 +68,17 @@ class Descriptor(object):
 
     .. code-block:: python
 
-        from distutils.version import StrictVersion
+        from packaging.version import Version
         from psij.descriptor import Descriptor
 
         __PSI_J_EXECUTORS__ = [
-            Descriptor(name=<name>, version=StrictVersion(<version_str>),
+            Descriptor(name=<name>, version=Version(<version_str>),
                        cls=<fqn_str>),
             ...
         ]
 
         __PSI_J_LAUNCHERS__ = [
-            Descriptor(name=<name>, version=StrictVersion(<version_str>),
+            Descriptor(name=<name>, version=Version(<version_str>),
                        cls=<fqn_str>),
             ...
         ]

--- a/src/psij/descriptor.py
+++ b/src/psij/descriptor.py
@@ -1,6 +1,6 @@
 """Executor/Launcher descriptor module."""
 
-from distutils.version import StrictVersion
+from packaging.version import Version
 from typing import TypeVar, Generic, Optional, Type, List
 
 T = TypeVar('T')
@@ -89,7 +89,7 @@ class Descriptor(object):
     `psij.executors.local.LocalJobExecutor`.
     """
 
-    def __init__(self, name: str, version: StrictVersion, cls: str,
+    def __init__(self, name: str, version: Version, cls: str,
                  aliases: Optional[List[str]] = None, nice_name: Optional[str] = None) -> None:
         """
         Parameters

--- a/tests/plugins1/psij-descriptors/descriptors.py
+++ b/tests/plugins1/psij-descriptors/descriptors.py
@@ -1,29 +1,29 @@
-from distutils.version import StrictVersion
+from packaging.version import Version
 from psij.descriptor import Descriptor
 
 __PSI_J_EXECUTORS__ = [
     # executor in the same path as descriptor; should load
-    Descriptor(name='p1-tp1', version=StrictVersion('0.0.1'),
+    Descriptor(name='p1-tp1', version=Version('0.0.1'),
                cls='_test_plugins1.ex1._Executor1'),
     # executor in different path, but sharing module; should NOT load
-    Descriptor(name='p2-tp1', version=StrictVersion('0.0.1'),
+    Descriptor(name='p2-tp1', version=Version('0.0.1'),
                cls='_test_plugins1.ex2._Executor2'),
     # executor in different path with no shared module; should NOT load
-    Descriptor(name='p2-tp3', version=StrictVersion('0.0.1'),
+    Descriptor(name='p2-tp3', version=Version('0.0.1'),
                cls='_test_plugins3.ex3._Executor3'),
     # noop executor that should have no reason to not load
-    Descriptor(name='_always_loads', version=StrictVersion('0.0.1'),
+    Descriptor(name='_always_loads', version=Version('0.0.1'),
                cls='_test_plugins1._always_loads_executor.AlwaysLoadsExecutor'),
     # noop executor with an import of a package that does not exist
-    Descriptor(name='_never_loads', version=StrictVersion('0.0.1'),
+    Descriptor(name='_never_loads', version=Version('0.0.1'),
                cls='_test_plugins1._never_loads_executor.NeverLoadsExecutor'),
     # an executor that exercises some of the batch test stuff
-    Descriptor(name='batch-test', version=StrictVersion('0.0.1'),
+    Descriptor(name='batch-test', version=Version('0.0.1'),
                cls='_batch_test._batch_test._TestJobExecutor')
 
 ]
 
 __PSI_J_LAUNCHERS__ = [
-    Descriptor(name='batch-test', version=StrictVersion('0.0.1'),
+    Descriptor(name='batch-test', version=Version('0.0.1'),
                cls='_batch_test._batch_test._TestLauncher')
 ]

--- a/tests/test_executor_versions.py
+++ b/tests/test_executor_versions.py
@@ -2,8 +2,7 @@
 
 # This is meant as a simple test file to check if psi/j was installed successfully
 
-from distutils.version import Version
-
+from packaging.version import Version
 from psij import JobExecutor
 
 


### PR DESCRIPTION
is deprecated in Python 3.1x ish.