### PR TITLE
When testing, always put the src dir before .packages in PYTHONPATH. 

### DIFF
--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -164,8 +164,8 @@ def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool =
 
     cwd = (dir / 'code') if clone else Path('.')
     env = dict(os.environ)
-    env['PYTHONPATH'] = str(cwd.resolve() / '.packages') \
-        + ':' + str(cwd.resolve() / 'src') \
+    env['PYTHONPATH'] = str(cwd.resolve() / 'src') \
+        + ':' + str(cwd.resolve() / '.packages') \
         + (':' + env['PYTHONPATH'] if 'PYTHONPATH' in env else '')
     subprocess.run(args, cwd=cwd.resolve(), env=env)
 


### PR DESCRIPTION
We don't want a dependency to install something that may have the same name as something in psij (including possibly a different version of psij itself) and hijack things.

@andre-merzky: We have a bit of a circular dependency: psij -> rp -> psij. This should be fine, since psij -> some_pilot_system -> psij is one of the intended scenarios. We may want to discuss whether such dependencies are necessarily package dependencies.