### PR TITLE
Requirements in release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/release.sh
+++ b/release.sh
@@ -48,6 +48,12 @@ if [ "$LAST" != "$TARGET_VERSION" ]; then
     error "Version $TARGET_VERSION is lower than the latest tagged version ($LAST)."
 fi
 
+if which twine >/dev/null; then
+	echo "Found twine"
+else
+	error "Twine was not found. Please install it and then re-run this script"
+fi
+
 echo "This will tag and release psij-python to version $TARGET_VERSION."
 echo -n "Type 'yes' if you want to continue: "
 read REPLY

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ if __name__ == '__main__':
         name='psij-python',
         version=VERSION,
 
-        description='''This is an implementation of the PSI/J (Portable Submission Interface for Jobs)
-        specification.''',
+        description='''This is an implementation of the PSI/J (Portable Submission Interface for Jobs) specification.''',
 
         author='The ExaWorks Team',
         author_email='hategan@mcs.anl.gov',


### PR DESCRIPTION
This PR ensures that `requirements.txt` is available in source release packages so that psij can be installed from those.

It also adds some minor fixes to the release/setup scripts.

Fixes #466 