### PR TITLE
Move filelock requirement from requirements.txt to requirements-tests…

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,3 +7,4 @@ pytest >= 6.2.0
 requests >= 2.25.1
 pytest-cov
 pytest-timeout
+filelock~=3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-filelock~=3.4
 psutil~=5.9
 pystache>=0.6.0
 typeguard~=2.12


### PR DESCRIPTION
….txt

since it appears to be the only place where it is actually used.

Fixes #465 