### PR TITLE
Newer versions of codespell seem to get triggered on pytest's assertIn

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,3 +15,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: codespell-project/actions-codespell@master
+        with:
+          ignore_words_list: assertIn


### PR DESCRIPTION
method, so add it to the codespell ignore list.