### PR TITLE
`squeue` fails if a job id is passed to `-j` for a job that is not in…

### DIFF
--- a/src/psij/executors/batch/slurm.py
+++ b/src/psij/executors/batch/slurm.py
@@ -147,7 +147,6 @@ class SlurmJobExecutor(BatchSchedulerExecutor):
 
     def get_status_command(self, native_ids: Collection[str]) -> List[str]:
         """See :meth:`~.BatchSchedulerExecutor.get_status_command`."""
-
         # we're not really using job arrays, so this is equivalent to the job ID. However, if
         # we were to use arrays, this would return one ID for the entire array rather than
         # listing each element of the array independently

--- a/src/psij/executors/batch/slurm.py
+++ b/src/psij/executors/batch/slurm.py
@@ -147,12 +147,11 @@ class SlurmJobExecutor(BatchSchedulerExecutor):
 
     def get_status_command(self, native_ids: Collection[str]) -> List[str]:
         """See :meth:`~.BatchSchedulerExecutor.get_status_command`."""
-        ids = ','.join(native_ids)
 
         # we're not really using job arrays, so this is equivalent to the job ID. However, if
         # we were to use arrays, this would return one ID for the entire array rather than
         # listing each element of the array independently
-        return [_SQUEUE_COMMAND, '-O', 'JobArrayID,StateCompact,Reason', '-t', 'all', '-j', ids]
+        return [_SQUEUE_COMMAND, '-O', 'JobArrayID,StateCompact,Reason', '-t', 'all', '--me']
 
     def parse_status_output(self, exit_code: int, out: str) -> Dict[str, JobStatus]:
         """See :meth:`~.BatchSchedulerExecutor.parse_status_output`."""


### PR DESCRIPTION
… the

queue (any more). Because we cannot guarantee that the query intervals are smaller than the intervals at which jobs get purged from the queue, failed `squeue` invocations can happen.

This change replaces the `-j` option with `--me`, which lists all jobs for a user. This has the potential of listing more jobs than necessary (since a user can have multiple PSI/J instances managing jobs).