### PR TITLE
On Frontier, the node count is mandatory. We should probably discuss

### DIFF
--- a/src/psij/executors/batch/slurm/slurm.mustache
+++ b/src/psij/executors/batch/slurm/slurm.mustache
@@ -38,6 +38,9 @@
 #SBATCH --cpus-per-task={{.}}
     {{/cpu_cores_per_process}}
 {{/job.spec.resources}}
+{{^job.spec.resources}}
+#SBATCH --nodes=1
+{{/job.spec.resources}}
 
 {{#formatted_job_duration}}
 #SBATCH --time={{.}}


### PR DESCRIPTION
having one node as a default and specify that in the spec. In the mean time, add one node as default for slurm.