### PR TITLE
Use default values for resource requests

### DIFF
--- a/src/psij/executors/batch/cobalt/cobalt.mustache
+++ b/src/psij/executors/batch/cobalt/cobalt.mustache
@@ -6,12 +6,12 @@
 #COBALT --cwd={{.}}
 {{/job.spec.directory}}
 {{#job.spec.resources}}
-    {{#node_count}}
+    {{#computed_node_count}}
 #COBALT --nodecount={{.}}
-    {{/node_count}}
-    {{#process_count}}
+    {{/computed_node_count}}
+    {{#computed_process_count}}
 #COBALT --proccount={{.}}
-    {{/process_count}}
+    {{/computed_process_count}}
 {{/job.spec.resources}}
 {{#formatted_job_duration}}
 #COBALT --time={{duration}}

--- a/src/psij/executors/batch/lsf/lsf.mustache
+++ b/src/psij/executors/batch/lsf/lsf.mustache
@@ -20,13 +20,13 @@
 
 {{#job.spec.resources}}
 
-    {{#node_count}}
+    {{#computed_node_count}}
 #BSUB -nnodes {{.}}
-    {{/node_count}}
+    {{/computed_node_count}}
 
-    {{#process_count}}
+    {{#computed_process_count}}
 #BSUB -n {{.}}
-    {{/process_count}}
+    {{/computed_process_count}}
 
     {{#gpu_cores_per_process}}
 #BSUB -gpu num={{.}}/task

--- a/src/psij/executors/batch/slurm/slurm.mustache
+++ b/src/psij/executors/batch/slurm/slurm.mustache
@@ -38,6 +38,9 @@
 #SBATCH --cpus-per-task={{.}}
     {{/cpu_cores_per_process}}
 {{/job.spec.resources}}
+{{^job.spec.resources}}
+#SBATCH --nodes=1
+{{/job.spec.resources}}
 
 {{#formatted_job_duration}}
 #SBATCH --time={{.}}

--- a/src/psij/executors/batch/slurm/slurm.mustache
+++ b/src/psij/executors/batch/slurm/slurm.mustache
@@ -22,9 +22,9 @@
 #SBATCH --ntasks={{.}}
     {{/computed_process_count}}
 
-    {{#computed_ppn}}
+    {{#computed_processes_per_node}}
 #SBATCH --ntasks-per-node={{.}}
-    {{/computed_ppn}}
+    {{/computed_processes_per_node}}
 
     {{#gpu_cores_per_process}}
 #SBATCH --gpus-per-task={{.}}

--- a/src/psij/executors/batch/slurm/slurm.mustache
+++ b/src/psij/executors/batch/slurm/slurm.mustache
@@ -14,17 +14,17 @@
 #SBATCH --exclusive
     {{/exclusive_node_use}}
 
-    {{#node_count}}
+    {{#computed_node_count}}
 #SBATCH --nodes={{.}}
-    {{/node_count}}
+    {{/computed_node_count}}
 
-    {{#process_count}}
+    {{#computed_process_count}}
 #SBATCH --ntasks={{.}}
-    {{/process_count}}
+    {{/computed_process_count}}
 
-    {{#processes_per_node}}
+    {{#computed_ppn}}
 #SBATCH --ntasks-per-node={{.}}
-    {{/processes_per_node}}
+    {{/computed_ppn}}
 
     {{#gpu_cores_per_process}}
 #SBATCH --gpus-per-task={{.}}
@@ -37,9 +37,6 @@
         hyperthreaded CPUs are used) or CPU core (for non-hyperthreaded CPUs).}}
 #SBATCH --cpus-per-task={{.}}
     {{/cpu_cores_per_process}}
-{{/job.spec.resources}}
-{{^job.spec.resources}}
-#SBATCH --nodes=1
 {{/job.spec.resources}}
 
 {{#formatted_job_duration}}

--- a/src/psij/job_executor.py
+++ b/src/psij/job_executor.py
@@ -14,9 +14,13 @@ from psij.job import Job, JobStatusCallback, FunctionJobStatusCallback
 from psij.job_executor_config import JobExecutorConfig
 from psij.job_launcher import Launcher
 from psij.job_spec import JobSpec
+from psij.resource_spec import ResourceSpecV1
 
 
 logger = logging.getLogger(__name__)
+
+
+_DEFAULT_RESOURCES = ResourceSpecV1()
 
 
 class JobExecutor(ABC):
@@ -92,6 +96,8 @@ class JobExecutor(ABC):
         spec = job.spec
         if not spec:
             raise InvalidJobException('Missing specification')
+        if not spec.resources:
+            spec.resources = _DEFAULT_RESOURCES
 
         if __debug__:
             if spec.environment is not None:

--- a/src/psij/resource_spec.py
+++ b/src/psij/resource_spec.py
@@ -54,7 +54,7 @@ class ResourceSpecV1(ResourceSpec):
                  processes_per_node: Optional[int] = None,
                  cpu_cores_per_process: Optional[int] = None,
                  gpu_cores_per_process: Optional[int] = None,
-                 exclusive_node_use: bool = True) -> None:
+                 exclusive_node_use: bool = False) -> None:
         """
         Some of the properties of this class are constrained. Specifically,
         `process_count = node_count * processes_per_node`. Specifying all constrained properties

--- a/tests/plugins1/_batch_test/test/test.mustache
+++ b/tests/plugins1/_batch_test/test/test.mustache
@@ -9,9 +9,9 @@ cd "{{.}}"
 export PSIJ_TEST_BATCH_EXEC_COUNT=1
 
 {{#job.spec.resources}}
-    {{#process_count}}
+    {{#computed_process_count}}
 export PSIJ_TEST_BATCH_EXEC_COUNT={{.}}
-    {{/process_count}}
+    {{/computed_process_count}}
 {{/job.spec.resources}}
 
 {{#job.spec.attributes}}

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -231,6 +231,7 @@ def test_resource_generation1() -> None:
     spec = JobSpec('/bin/date', resources=res)
     job = Job(spec=spec)
     ex = JobExecutor.get_instance('slurm')
+    assert isinstance(ex, BatchSchedulerExecutor)
     with TemporaryFile(mode='w+') as f:
         ex.generate_submit_script(job, ex._create_script_context(job), f)
         f.seek(0)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -224,3 +224,16 @@ def test_submit_script_generation(exec_name: str) -> None:
                      lambda k, v: setattr(attrs, k, v))
     _check_str_attrs(ex, job, [prefix + '.cust_attr1', prefix + '.cust_attr2'],
                      lambda k, v: c_attrs.__setitem__(k, v))
+
+
+def test_resource_generation1() -> None:
+    res = ResourceSpecV1()
+    spec = JobSpec('/bin/date', resources=res)
+    job = Job(spec=spec)
+    ex = JobExecutor.get_instance('slurm')
+    with TemporaryFile(mode='w+') as f:
+        ex.generate_submit_script(job, ex._create_script_context(job), f)
+        f.seek(0)
+        contents = f.read()
+        if contents.find('--exclusive') != -1:
+            pytest.fail('Spurious exclusive flag')


### PR DESCRIPTION
Some scheduler configurations (e.g., Frontier@ORNL) require a node count. We do not mandate one, with the assumption that schedulers will have defaults and, if not, the (possibly misguided) spirit of PSI/J being a pass-through device which lets the scheduler decide how to handle a missing node count specification is maintained.

The problem exists when either a resource spec is missing and when the resource spec only specifies a process count (because the Slurm template does not use the computed counts).

This breaks our tests on Frontier. That, in itself, could be a statement that our tests are broken and should always specify a node count. More importantly, however, this breaks abstraction.

The point is that if we avoid defining defaults in PSI/J under the assumption that the scheduler will do the right thing with a missing value, that does not lead to uniform behavior, as evidenced above. Furthermore, the purpose of PSI/J is to clearly (and somewhat uniformly) define what a particular combination of values in the job spec, which, in this particular case, it fails to do. I would, therefore, argue that the meaning of a missing resource spec should be understood as "one process on one compute node".

The potential negative implication that I can think of is when some hypothetical scheduler might be configured to allocate fractional compute nodes when only a process count is specified, leading to an inability to specify such jobs on such schedulers, although when I have seen such scenarios, the scheduler tends to repurpose the notion of a node to mean the smallest fractional unit of a physical node.

This PR does two things:
- adds a default resource spec right before submission (in JobExecutor._check_job) and
- replaces instances of raw resource numbers in submit script templates with the corresponding computed values, which are always defined.