### PR TITLE
Adds a `multi_node_queue_name` ci config option

### DIFF
--- a/testing.conf
+++ b/testing.conf
@@ -116,6 +116,14 @@ queue_name =
 
 
 #
+# If a different queue is used for multi-node jobs, specify it here. If empty,
+# queue_name is used for both single-node and multi-node jobs.
+#
+
+multi_node_queue_name =
+
+
+#
 # If you need a project/account for billing purposes, enter it here.
 #
 

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -147,7 +147,8 @@ def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool =
         args.append('--branch-name-override')
         args.append(fake_branch_name)
     for opt in ['maintainer_email', 'executors', 'server_url', 'key', 'max_age',
-                'custom_attributes', 'queue_name', 'project_name', 'account']:
+                'custom_attributes', 'queue_name', 'multi_node_queue_name',
+                'project_name', 'account']:
         try:
             val = get_conf(conf, opt)
             args.append('--' + opt.replace('_', '-'))

--- a/tests/ci_runner.py
+++ b/tests/ci_runner.py
@@ -151,8 +151,9 @@ def run_branch_tests(conf: Dict[str, str], dir: Path, run_id: str, clone: bool =
                 'project_name', 'account']:
         try:
             val = get_conf(conf, opt)
-            args.append('--' + opt.replace('_', '-'))
-            args.append(val)
+            if val != '':
+                args.append('--' + opt.replace('_', '-'))
+                args.append(val)
         except KeyError:
             # sometimes options get added; when they do, they could prevent
             # old test cycles from working, if their configs don't contain

--- a/tests/executor_test_params.py
+++ b/tests/executor_test_params.py
@@ -6,6 +6,7 @@ class ExecutorTestParams:
     """A class holding executor, launcher, url pairs."""
 
     def __init__(self, spec: str, queue_name: Optional[str] = None,
+                 multi_node_queue_name: Optional[str] = None,
                  account: Optional[str] = None,
                  custom_attributes_raw: Optional[Dict[str, Dict[str, object]]] = None) \
             -> None:
@@ -19,6 +20,9 @@ class ExecutorTestParams:
             url are specified, the string should be formatted as "<executor>::<url>".
         queue_name
             An optional queue to submit the job to
+        multi_node_queue_name
+            An optional multi-node queue name used for multi-node jobs. If not specified,
+            `queue_name` is used for both single and multi-node jobs.
         account
             An optional account to use for billing purposes.
         custom_attributes
@@ -35,6 +39,10 @@ class ExecutorTestParams:
             self.url = None
 
         self.queue_name = queue_name
+        if multi_node_queue_name is None:
+            self.multi_node_queue_name = queue_name
+        else:
+            self.multi_node_queue_name = multi_node_queue_name
         self.account = account
         self.custom_attributes_raw = custom_attributes_raw
         self.custom_attributes: Dict[str, object] = {}


### PR DESCRIPTION
If specified, this option allows multi-node tests to run using a different queue than the one in `queue_name`. The wisdom of this is that on certain systems it makes sense to use more restrictive but less expensive queues by default, and only use more expensive, multi-node queues when strictly needed. In a sense, this could be hacked using `custom_attributes` and test filters, which some deployments do, but it is awkward and difficult to set up in a way that predicts all future multi-node tests.

When merged, the new `ci_runner.py` will automatically be used by all deployed tests. It was modified to not pass config
options that are not set, and all such options should have defaults in the `conftest.py` arg parser, both old and new.

This addition will affect tests that are currently deployed as follows (new and old refer to post and pre merging this PR):
1. old_clone -> new_pr: OK (new PRs work with the old options)
2. old_clone -> old_pr: OK (has old config and new ci_runner does not pass missing options)
3. new_clone -> old_pr: Not OK (will have to update PR - only one ATM; will pass new option which is not recognized)
4. new_clone -> new_pr: OK by construction

