### PR TITLE
Add "quiet" flag for mpirun to avoid messages interfering with output capture.

### DIFF
--- a/src/psij/launchers/scripts/mpi_launch.sh
+++ b/src/psij/launchers/scripts/mpi_launch.sh
@@ -14,7 +14,7 @@ pre_launch
 
 set +e
 if [ "$IS_OPENMPI" == "1" ]; then
-    mpirun --oversubscribe -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN
+    mpirun --oversubscribe -q -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN
 else
     mpirun -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN
 fi

--- a/src/psij/launchers/scripts/mpi_launch.sh
+++ b/src/psij/launchers/scripts/mpi_launch.sh
@@ -6,14 +6,20 @@ _PSI_J_PROCESS_COUNT="$1"
 shift
 
 IS_OPENMPI=0
-if mpirun -version | grep "Open MPI" >/dev/null 2>&1; then
+IS_OPENMPI_5=0
+if mpirun -version | grep "(Open MPI) 5" >/dev/null 2>&1; then
+    IS_OPENMPI_5=1
+elif mpirun -version | grep "Open MPI" >/dev/null 2>&1; then
     IS_OPENMPI=1
 fi
 
 pre_launch
 
 set +e
-if [ "$IS_OPENMPI" == "1" ]; then
+if [ "$IS_OPENMPI_5" == "1" ]; then
+    # there is no -q parameter in OMPI 5
+    mpirun --oversubscribe -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN
+elif [ "$IS_OPENMPI" == "1" ]; then
     mpirun --oversubscribe -q -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN
 else
     mpirun -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN


### PR DESCRIPTION
mpirun, on some systems, can print "helpful messages". Except they aren't
helpful for us trying to run automated systems with predictable behavior.