### PR TITLE
Wait for job to complete in `test_list`

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -167,6 +167,8 @@ def test_list(execparams: ExecutorTestParams) -> None:
     assert job.native_id is not None
     ids = ex.list()
     assert job.native_id in ids
+    status = job.wait(timeout=_get_timeout(execparams))
+    assert_completed(job, status)
 
 
 def _get_batch_executors() -> List[str]:


### PR DESCRIPTION
On some machines, the tests use a fast queue for simple jobs that only allow one (or a small number of) job(s) to be queued at a time. If we don't wait for the job to complete, the next job may lead to a violation of queue policies.