### PR TITLE
mpirun can mangle tagged output lines, so use heuristics to fix that.

### DIFF
--- a/src/psij/launchers/scripts/mpi_launch.sh
+++ b/src/psij/launchers/scripts/mpi_launch.sh
@@ -16,28 +16,22 @@ fi
 pre_launch
 
 filter_out() {
-    sed -nE 's/^\[[^]]+\]<stdout>:(.*)/\1/p'
-}
-
-filter_err() {
-    sed -nE 's/^\[[^]]+\]<stderr>:(.*)/\1/p'
+    # must start with [n,n]<stdout>:
+    # may contain one or more [n,n]<stdout>: lodged into the line
+    sed -nE 's/^\[[^]]+\]<std[oe][ur][tr]>:(.*)/\1/p' | sed -E 's/\[[^]]+\]<std[oe][ur][tr]>://g'
 }
 
 filter_out_5() {
-    sed -nE 's/^\[[^]]+\]<stdout>: (.*)/\1/p'
-}
-
-filter_err_5() {
-    sed -nE 's/^\[[^]]+\]<stderr>: (.*)/\1/p'
+    sed -nE 's/^\[[^]]+\]<std[oe][ur][tr]>: (.*)/\1/p'
 }
 
 set +e
 if [ "$IS_OPENMPI_5" == "1" ]; then
     mpirun --oversubscribe --output TAG -n $_PSI_J_PROCESS_COUNT "$@" \
-        1> >(filter_out_5 > $_PSI_J_STDOUT) 2> >(filter_err_5 > $_PSI_J_STDERR) <$_PSI_J_STDIN
+        1> >(filter_out_5 > $_PSI_J_STDOUT) 2> >(filter_out_5 > $_PSI_J_STDERR) <$_PSI_J_STDIN
 elif [ "$IS_OPENMPI" == "1" ]; then
     mpirun --oversubscribe --tag-output -q -n $_PSI_J_PROCESS_COUNT "$@" \
-        1> >(filter_out > "$_PSI_J_STDOUT") 2> >(filter_err > $_PSI_J_STDERR) <$_PSI_J_STDIN
+        1> >(filter_out > "$_PSI_J_STDOUT") 2> >(filter_out > $_PSI_J_STDERR) <$_PSI_J_STDIN
 else
     mpirun -n $_PSI_J_PROCESS_COUNT "$@" 1>$_PSI_J_STDOUT 2>$_PSI_J_STDERR <$_PSI_J_STDIN
 fi


### PR DESCRIPTION
Of course, the saga is not over.

When specifying `--tag-output`, mpirun is supposed to "tag each line" with `[jobid, rank]<stdxxx>:`. It mostly does. However
it occasionally does something else. Assume that `a.txt` and `b.txt` contain `ABCD` and `EFGH`, respectively. Running
`mpirun --tag-output -n 1 cat a.txt b.txt` mostly produces 

```
[1,0]<stdout>:ABCDEFGH
```
Occasionally, the following shows up instead:
```
[1,0]<stdout>:ABCD[1,0]<stdout>:EFGH
```
That is indistinguishable from `b.txt` having contained `[1,0]<stdout>:EFGH`. This, my guess would be, is due to a brief delay between the files that `cat` introduces. This can be verified by adding more files for `cat` and seeing all kinds of combinations of tags popping out in the middle of a line.

One solution is to use heuristics and consider an output line to begin with the tag while also assuming that it is very unlikely for the application to produce the tag in the middle. Hence, we can filter on lines that start with the tag and then
remove any other tags that appear in the middle. This should significantly reduce the likelihood of random mishaps, but transforms it into less likely but deterministic mishaps (e.g., running `echo "[1, 0]<stdout>:bla"` through mpirun.

Another choice is [--xml](https://github.com/ExaWorks/psij-python/blob/mpirun_output_take_3/src/psij/launchers/scripts/mpi_launch.sh). Unfortunately, parsing XML in POSIX only is difficult and many simplifying assumptions are made. Nonetheless, that branch appears to work fine with OpenMPI 4, so, perhaps, the loss in clarity might not outweigh the benefits.
