### PR TITLE
Setting the `project_name` in the constructor can reset the `account`

### DIFF
--- a/src/psij/job_attributes.py
+++ b/src/psij/job_attributes.py
@@ -53,7 +53,8 @@ class JobAttributes(object):
         self.account = account
         self.duration = duration
         self.queue_name = queue_name
-        self.project_name = project_name
+        if project_name is not None:
+            self.project_name = project_name
         self.reservation_id = reservation_id
         self._custom_attributes = custom_attributes
 


### PR DESCRIPTION
attribute to `None` due to the setter. So only set if not the default.