### PR TITLE
Updated Typeguard requirement to >=4.0.0. While Typeguard 3.x.x is 2 …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 psutil >=5.9, <=7.0.0
 pystache>=0.6.0
-typeguard>=3.0.1
+typeguard>=4.0.0
 packaging >= 24.0, <= 25.0


### PR DESCRIPTION
…years

old or so, it is unfortunately preventing PSI/J from running (see https://github.com/agronholm/typeguard/issues/318 and https://github.com/ExaWorks/psij-python/issues/526).
